### PR TITLE
Update readme, allow to run scripts from any working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,12 @@ This repo is WIP and is an actively on-going research effort.
 
 ## Installation
 
-Requires the latest `autogluon` installed (obtainable via `pip install autogluon` or installing from source).
+Requires the latest `autogluon` installed (can be installed from source).
 
 ## Quick-start
 
 You can try the code out to generate a zeroshot portfolio immediately by running `scripts/run_simulate_zs_single_best.py`.
-Note: You will need `ray` installed (included in `autogluon` unless running in MacOS) to run without edits.
-If running on MacOS, edit the script to use `native` backend instead of `ray` backend.
-
-Note: You will need to be in the working directory of `scripts/` to load the files correctly. This will likely change in future.
+Note: You will need `ray` installed to run without edits.
 
 ## Related Repositories
 

--- a/autogluon_zeroshot/contexts/context_2022_10_13.py
+++ b/autogluon_zeroshot/contexts/context_2022_10_13.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from autogluon.common.loaders import load_pd
 
 from ..loaders import load_configs, load_results, combine_results_with_score_val
@@ -8,17 +10,19 @@ def load_context_2022_10_13(folds=None, load_zeroshot_pred_proba=False) -> (Zero
     if folds is None:
         folds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-    path_prefix = '../data/results/all_v3'
+    data_root = Path(__file__).parent.parent.parent / 'data'
+    results_root = data_root / 'results'
+    all_v3_results_root = results_root / "all_v3"
     df_results, df_results_by_dataset, df_raw, df_metadata = load_results(
-        results=f"{path_prefix}/results_ranked_valid.csv",
-        results_by_dataset=f"{path_prefix}/results_ranked_by_dataset_valid.parquet",
-        raw=f"{path_prefix}/openml_ag_2022_10_13_zs_models.parquet",
-        metadata=f"../data/metadata/task_metadata.csv",
+        results=str(all_v3_results_root / "results_ranked_valid.csv"),
+        results_by_dataset=str(all_v3_results_root / "results_ranked_by_dataset_valid.parquet"),
+        raw=str(all_v3_results_root / "openml_ag_2022_10_13_zs_models.parquet"),
+        metadata=str(data_root / "metadata" / "task_metadata.csv"),
     )
     df_results_by_dataset = combine_results_with_score_val(df_raw, df_results_by_dataset)
 
     # Load in real framework results to score against
-    path_prefix_automl = '../data/results/automl'
+    path_prefix_automl = results_root / 'automl'
     df_results_by_dataset_automl = load_pd.load(f'{path_prefix_automl}/results_ranked_by_dataset_valid.csv')
 
     zsc = ZeroshotSimulatorContext(
@@ -28,8 +32,8 @@ def load_context_2022_10_13(folds=None, load_zeroshot_pred_proba=False) -> (Zero
         folds=folds,
     )
 
-    configs_prefix_1 = '../data/configs/configs_20221004'
-    configs_prefix_2 = '../data/configs'
+    configs_prefix_1 = str(data_root / 'configs/configs_20221004')
+    configs_prefix_2 = str(data_root / 'configs')
     config_files_to_load = [
         f'{configs_prefix_1}/configs_catboost.json',
         f'{configs_prefix_1}/configs_fastai.json',
@@ -45,8 +49,8 @@ def load_context_2022_10_13(folds=None, load_zeroshot_pred_proba=False) -> (Zero
     zeroshot_pred_proba = None
     zeroshot_gt = None
     if load_zeroshot_pred_proba:
-        path_zs_pred_proba = f'{path_prefix}/zeroshot_pred_proba_2022_10_13_zs.pkl'
-        path_zs_gt = f'{path_prefix}/zeroshot_gt_2022_10_13_zs.pkl'
+        path_zs_pred_proba = str(all_v3_results_root / 'zeroshot_pred_proba_2022_10_13_zs.pkl')
+        path_zs_gt = str(all_v3_results_root / 'zeroshot_gt_2022_10_13_zs.pkl')
         zeroshot_pred_proba, zeroshot_gt = zsc.load_zeroshot_pred_proba(path_pred_proba=path_zs_pred_proba,
                                                                         path_gt=path_zs_gt)
 

--- a/scripts/run_download_zeroshot_pred_proba.py
+++ b/scripts/run_download_zeroshot_pred_proba.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from autogluon.common.loaders import load_pkl
 from autogluon.common.savers import save_pkl
 
@@ -12,7 +14,7 @@ if __name__ == '__main__':
     zeroshot_gt = load_pkl.load(path_gt)
     zeroshot_pred_proba = load_pkl.load(path_pred_proba)
 
-    save_path = '../data/results/all_v3/'
+    save_path = Path(__file__).parent.parent / 'data' / 'results' / 'all_v3'
 
-    save_pkl.save(path=save_path + path_gt_name, object=zeroshot_gt)
-    save_pkl.save(path=save_path + path_pred_proba_name, object=zeroshot_pred_proba)
+    save_pkl.save(path=str(save_path / path_gt_name), object=zeroshot_gt)
+    save_pkl.save(path=str(save_path / path_pred_proba_name), object=zeroshot_pred_proba)

--- a/scripts/run_generate_all_configs.py
+++ b/scripts/run_generate_all_configs.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from autogluon.common.savers import save_json
 
 from autogluon_zeroshot.models.lightgbm.generate import generate_configs_lightgbm
@@ -19,12 +20,12 @@ if __name__ == '__main__':
     configs_knn = generate_configs_knn()
     configs_rf = generate_configs_random_forest()
     configs_xt = generate_configs_extra_trees()
-
-    save_json.save(path='../data/configs/configs_lightgbm.json', obj=configs_lightgbm)
-    save_json.save(path='../data/configs/configs_catboost.json', obj=configs_catboost)
-    save_json.save(path='../data/configs/configs_xgboost.json', obj=configs_xgboost)
-    save_json.save(path='../data/configs/configs_fastai.json', obj=configs_fastai)
-    save_json.save(path='../data/configs/configs_nn_torch.json', obj=configs_nn_torch)
-    save_json.save(path='../data/configs/configs_knn.json', obj=configs_knn)
-    save_json.save(path='../data/configs/configs_rf.json', obj=configs_rf)
-    save_json.save(path='../data/configs/configs_xt.json', obj=configs_xt)
+    json_root = Path(__file__).parent.parent / 'data' / 'configs'
+    save_json.save(path=json_root / 'configs_lightgbm.json', obj=configs_lightgbm)
+    save_json.save(path=json_root / 'configs_catboost.json', obj=configs_catboost)
+    save_json.save(path=json_root / 'configs_xgboost.json', obj=configs_xgboost)
+    save_json.save(path=json_root / 'configs_fastai.json', obj=configs_fastai)
+    save_json.save(path=json_root / 'configs_nn_torch.json', obj=configs_nn_torch)
+    save_json.save(path=json_root / 'configs_knn.json', obj=configs_knn)
+    save_json.save(path=json_root / 'configs_rf.json', obj=configs_rf)
+    save_json.save(path=json_root / 'configs_xt.json', obj=configs_xt)

--- a/scripts/run_generate_amlb_config.py
+++ b/scripts/run_generate_amlb_config.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 from autogluon.common.loaders import load_json
 
 
 if __name__ == '__main__':
-    configs_zs = load_json.load(path='../data/configs/zeroshot/configs_zs_20221004.json')
+    json_root = Path(__file__).parent.parent / 'data' / 'configs' / 'zeroshot'
+
+    configs_zs = load_json.load(path=json_root / 'configs_zs_20221004.json')
 
     hyperparameters_dict = {}
 

--- a/scripts/run_shrink_result_disk_size.py
+++ b/scripts/run_shrink_result_disk_size.py
@@ -1,14 +1,17 @@
+from pathlib import Path
 
 from autogluon_zeroshot.utils.result_utils import shrink_result_file_size, shrink_ranked_result_file_size
 
 
 if __name__ == '__main__':
+    result_root = Path(__file__).parent.parent / 'data' / 'results' / 'all_v3'
+
     # Compresses CSV to Parquet (311.2 MB -> 19.2 MB)
-    path_load = '../data/results/all_v3/openml_ag_2022_10_13_zs_models.csv'
-    path_save = '../data/results/all_v3/openml_ag_2022_10_13_zs_models.parquet'
+    path_load = result_root / 'openml_ag_2022_10_13_zs_models.csv'
+    path_save = result_root / 'openml_ag_2022_10_13_zs_models.parquet'
     shrink_result_file_size(path_load=path_load, path_save=path_save)
 
     # Compresses CSV to Parquet (76.4 MB -> 22 MB)
-    path_load = '../data/results/all_v3/results_ranked_by_dataset_valid.csv'
-    path_save = '../data/results/all_v3/results_ranked_by_dataset_valid.parquet'
+    path_load = result_root / 'results_ranked_by_dataset_valid.csv'
+    path_save = result_root / 'results_ranked_by_dataset_valid.parquet'
     shrink_ranked_result_file_size(path_load=path_load, path_save=path_save)

--- a/scripts/run_simulate_zs_ensemble.py
+++ b/scripts/run_simulate_zs_ensemble.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 
 from autogluon.common.savers import save_pkl
@@ -50,4 +52,4 @@ if __name__ == '__main__':
     score_total = score_total / len_datasets_total
     print(f'Final Score: {score_total}')
 
-    save_pkl.save(path='./sim_results/ensemble_result.pkl', object=results_total)
+    save_pkl.save(path=str(Path(__file__).parent / 'sim_results' / 'ensemble_result.pkl'), object=results_total)

--- a/scripts/run_simulate_zs_single_best.py
+++ b/scripts/run_simulate_zs_single_best.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 
 from autogluon.common.savers import save_pkl
@@ -52,4 +54,5 @@ if __name__ == '__main__':
     score_total = score_total / len_datasets_total
     print(f'Final Score: {score_total}')
 
-    save_pkl.save(path='./sim_results/single_best_result.pkl', object=results_total)
+    save_pkl.save(path=str(Path(__file__).parent / 'sim_results' / 'single_best_result.pkl'), object=results_total)
+


### PR DESCRIPTION
This PR is optional/cosmetic. 

While running the examples, it was convenient for me to be agnostic the working directory. 

I also removed the mention of ray as it runs fine on my mac, and mentions that AG must be installed from source (because load_json is not available in current release for instance).