### PR TITLE
Benchmark to evaluate multiple strategies

### DIFF
--- a/autogluon_zeroshot/contexts/context_2022_10_13.py
+++ b/autogluon_zeroshot/contexts/context_2022_10_13.py
@@ -7,6 +7,13 @@ from ..simulation.tabular_predictions import TabularModelPredictions
 
 
 def load_context_2022_10_13(folds=None, load_zeroshot_pred_proba=False, lazy_format=False) -> Tuple[ZeroshotSimulatorContext, dict, TabularModelPredictions, dict]:
+    """
+    :param folds:
+    :param load_zeroshot_pred_proba:
+    :param lazy_format: whether to load with a format where all data is in memory (`TabularPicklePredictions`) or a
+    format where data is loaded on the fly (`TabularPicklePerTaskPredictions`). Both formats have the same interface.
+    :return:
+    """
     if folds is None:
         folds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 

--- a/autogluon_zeroshot/contexts/context_2022_10_13.py
+++ b/autogluon_zeroshot/contexts/context_2022_10_13.py
@@ -1,12 +1,12 @@
-from pathlib import Path
-
+from typing import Tuple
 from autogluon.common.loaders import load_pd
 
 from ..loaders import load_configs, load_results, combine_results_with_score_val, Paths
 from ..simulation.simulation_context import ZeroshotSimulatorContext
+from ..simulation.tabular_predictions import TabularModelPredictions
 
 
-def load_context_2022_10_13(folds=None, load_zeroshot_pred_proba=False, lazy_format=True,) -> (ZeroshotSimulatorContext, dict, dict, dict):
+def load_context_2022_10_13(folds=None, load_zeroshot_pred_proba=False, lazy_format=False) -> Tuple[ZeroshotSimulatorContext, dict, TabularModelPredictions, dict]:
     if folds is None:
         folds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 

--- a/autogluon_zeroshot/contexts/context_2022_10_13.py
+++ b/autogluon_zeroshot/contexts/context_2022_10_13.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from autogluon.common.loaders import load_pd
 
-from ..loaders import load_configs, load_results, combine_results_with_score_val
+from ..loaders import load_configs, load_results, combine_results_with_score_val, Paths
 from ..simulation.simulation_context import ZeroshotSimulatorContext
 
 
@@ -10,19 +10,16 @@ def load_context_2022_10_13(folds=None, load_zeroshot_pred_proba=False) -> (Zero
     if folds is None:
         folds = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-    data_root = Path(__file__).parent.parent.parent / 'data'
-    results_root = data_root / 'results'
-    all_v3_results_root = results_root / "all_v3"
     df_results, df_results_by_dataset, df_raw, df_metadata = load_results(
-        results=str(all_v3_results_root / "results_ranked_valid.csv"),
-        results_by_dataset=str(all_v3_results_root / "results_ranked_by_dataset_valid.parquet"),
-        raw=str(all_v3_results_root / "openml_ag_2022_10_13_zs_models.parquet"),
-        metadata=str(data_root / "metadata" / "task_metadata.csv"),
+        results=str(Paths.all_v3_results_root / "results_ranked_valid.csv"),
+        results_by_dataset=str(Paths.all_v3_results_root / "results_ranked_by_dataset_valid.parquet"),
+        raw=str(Paths.all_v3_results_root / "openml_ag_2022_10_13_zs_models.parquet"),
+        metadata=str(Paths.data_root / "metadata" / "task_metadata.csv"),
     )
     df_results_by_dataset = combine_results_with_score_val(df_raw, df_results_by_dataset)
 
     # Load in real framework results to score against
-    path_prefix_automl = results_root / 'automl'
+    path_prefix_automl = Paths.results_root / 'automl'
     df_results_by_dataset_automl = load_pd.load(f'{path_prefix_automl}/results_ranked_by_dataset_valid.csv')
 
     zsc = ZeroshotSimulatorContext(
@@ -32,8 +29,8 @@ def load_context_2022_10_13(folds=None, load_zeroshot_pred_proba=False) -> (Zero
         folds=folds,
     )
 
-    configs_prefix_1 = str(data_root / 'configs/configs_20221004')
-    configs_prefix_2 = str(data_root / 'configs')
+    configs_prefix_1 = str(Paths.data_root / 'configs/configs_20221004')
+    configs_prefix_2 = str(Paths.data_root / 'configs')
     config_files_to_load = [
         f'{configs_prefix_1}/configs_catboost.json',
         f'{configs_prefix_1}/configs_fastai.json',
@@ -49,8 +46,8 @@ def load_context_2022_10_13(folds=None, load_zeroshot_pred_proba=False) -> (Zero
     zeroshot_pred_proba = None
     zeroshot_gt = None
     if load_zeroshot_pred_proba:
-        path_zs_pred_proba = str(all_v3_results_root / 'zeroshot_pred_proba_2022_10_13_zs.pkl')
-        path_zs_gt = str(all_v3_results_root / 'zeroshot_gt_2022_10_13_zs.pkl')
+        path_zs_pred_proba = str(Paths.all_v3_results_root / 'zeroshot_pred_proba_2022_10_13_zs.pkl')
+        path_zs_gt = str(Paths.all_v3_results_root / 'zeroshot_gt_2022_10_13_zs.pkl')
         zeroshot_pred_proba, zeroshot_gt = zsc.load_zeroshot_pred_proba(path_pred_proba=path_zs_pred_proba,
                                                                         path_gt=path_zs_gt)
 

--- a/autogluon_zeroshot/loaders/__init__.py
+++ b/autogluon_zeroshot/loaders/__init__.py
@@ -1,2 +1,10 @@
+from pathlib import Path
+
 from ._configs import load_configs
 from ._results import load_results, combine_results_with_score_val
+
+
+class Paths:
+    data_root: Path = Path(__file__).parent.parent.parent / 'data'
+    results_root: Path = data_root / 'results'
+    all_v3_results_root: Path = results_root / "all_v3"

--- a/autogluon_zeroshot/simulation/config_generator.py
+++ b/autogluon_zeroshot/simulation/config_generator.py
@@ -8,7 +8,6 @@ from sklearn.model_selection import KFold
 
 from .configuration_list_scorer import ConfigurationListScorer
 from .simulation_context import ZeroshotSimulatorContext
-from ..utils import catchtime
 
 
 @ray.remote
@@ -54,12 +53,13 @@ class ZeroshotConfigGenerator:
             if not valid_configs:
                 break
 
+
             time_start = time.time()
             best_next_config, best_score = selector(valid_configs, zeroshot_configs, config_scorer)
             time_end = time.time()
 
             zeroshot_configs.append(best_next_config)
-            msg = f'{iteration}\t: {round(best_score, 2)} | {round(time_end - time_start, 2)}s | {self.backend}'
+            msg = f'{iteration}\t: {round(best_score, 2)} | {round(time_end-time_start, 2)}s | {self.backend}'
             if config_scorer_test:
                 score_test = config_scorer_test.score(zeroshot_configs)
                 msg += f'\tTest: {round(score_test, 2)}'
@@ -175,7 +175,7 @@ class ZeroshotConfigGeneratorCV:
     def run(self):
         fold_results = []
         for i, (train_index, test_index) in enumerate(self.kf.split(self.unique_datasets)):
-            print(f'Fitting Fold {i + 1}...')
+            print(f'Fitting Fold {i+1}...')
             X_train, X_test = list(self.unique_datasets[train_index]), list(self.unique_datasets[test_index])
             X_train_fold = []
             X_test_fold = []
@@ -185,7 +185,7 @@ class ZeroshotConfigGeneratorCV:
                 X_test_fold += self.dataset_parent_to_fold_map[d]
             zeroshot_configs_fold, score_fold = self.run_fold(X_train_fold, X_test_fold)
             results_fold = {
-                'fold': i + 1,
+                'fold': i+1,
                 'X_train': X_train,
                 'X_test': X_test,
                 'X_train_fold': X_train_fold,
@@ -220,93 +220,3 @@ class ZeroshotConfigGeneratorCV:
         print(f'score: {score}')
 
         return zeroshot_configs, score
-
-
-class RandomGeneratorCV:
-    def __init__(
-        self,
-        n_splits: int,
-        zeroshot_simulator_context: ZeroshotSimulatorContext,
-        config_scorer: ConfigurationListScorer,
-        configs: List[str] = None,
-        backend='ray'
-    ):
-        assert n_splits >= 2
-        self.n_splits = n_splits
-        self.backend = backend
-        self.config_scorer = config_scorer
-        self.unique_datasets_fold = np.array(config_scorer.datasets)
-        self.unique_datasets_map = zeroshot_simulator_context.dataset_name_to_tid_dict
-        self.unique_datasets = set()
-        self.dataset_parent_to_fold_map = dict()
-        for d in self.unique_datasets_fold:
-            dataset_parent = self.unique_datasets_map[d]
-            self.unique_datasets.add(dataset_parent)
-            if dataset_parent in self.dataset_parent_to_fold_map:
-                self.dataset_parent_to_fold_map[dataset_parent].append(d)
-            else:
-                self.dataset_parent_to_fold_map[dataset_parent] = [d]
-        for d in self.dataset_parent_to_fold_map:
-            self.dataset_parent_to_fold_map[d] = sorted(self.dataset_parent_to_fold_map[d])
-        self.unique_datasets = np.array((sorted(list(self.unique_datasets))))
-
-        if configs is None:
-            configs = zeroshot_simulator_context.get_configs()
-        self.configs = configs
-
-        self.kf = KFold(n_splits=self.n_splits, random_state=0, shuffle=True)
-
-    def run(self):
-        fold_results = []
-        for i, (train_index, test_index) in enumerate(self.kf.split(self.unique_datasets)):
-            print(f'Fitting Fold {i + 1}...')
-            X_train, X_test = list(self.unique_datasets[train_index]), list(self.unique_datasets[test_index])
-            X_train_fold = []
-            X_test_fold = []
-            for d in X_train:
-                X_train_fold += self.dataset_parent_to_fold_map[d]
-            for d in X_test:
-                X_test_fold += self.dataset_parent_to_fold_map[d]
-            zeroshot_configs_fold, score_fold = self.run_fold(X_train_fold, X_test_fold)
-            results_fold = {
-                'fold': i + 1,
-                'X_train': X_train,
-                'X_test': X_test,
-                'X_train_fold': X_train_fold,
-                'X_test_fold': X_test_fold,
-                'score': score_fold,
-                'selected_configs': zeroshot_configs_fold,
-            }
-            fold_results.append(results_fold)
-        return fold_results
-
-    def random_config(self, ensemble_size: int):
-        return [
-            np.random.choice(self.configs)
-            for _ in range(ensemble_size)
-        ]
-
-    def run_fold(self, X_train, X_test):
-        num_iterations = 20
-        ensemble_size = 10
-
-        config_scorer_train = self.config_scorer.subset(datasets=X_train)
-        config_scorer_test = self.config_scorer.subset(datasets=X_test)
-
-        # draw 20 configs, pick best
-        best_config = None
-        best_score = np.inf
-        for _ in range(num_iterations):
-            random_config = self.random_config(ensemble_size)
-            with catchtime("eval ensemble"):
-                new_score = config_scorer_train.score(random_config)
-            print(new_score, random_config)
-            if new_score < best_score:
-                best_score = new_score
-                best_config = best_config
-
-        # Consider making test scoring optional here
-        score = config_scorer_test.score(best_config)
-        print(f'score: {score}')
-
-        return best_config, score

--- a/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
+++ b/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
@@ -60,8 +60,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         y_val = self.zeroshot_gt[dataset][fold]['y_val']
         y_test = self.zeroshot_gt[dataset][fold]['y_test']
 
-        pred_proba_dict_val = self.zeroshot_pred_proba[dataset][fold]['pred_proba_dict_val']
-        pred_proba_dict_test = self.zeroshot_pred_proba[dataset][fold]['pred_proba_dict_test']
+        pred_proba_dict_val, pred_proba_dict_test = self.zeroshot_pred_proba.score(dataset=dataset, fold=fold, splits=['val', 'test'], models=models)
         weighted_ensemble = EnsembleSelection(
             ensemble_size=self.ensemble_size,
             problem_type=problem_type,
@@ -69,14 +68,8 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             **self.ensemble_selection_kwargs,
         )
 
-        a = []
-        for m in models:
-            a.append(pred_proba_dict_val[m])
-        weighted_ensemble.fit(predictions=a, labels=y_val)
-        b = []
-        for m in models:
-            b.append(pred_proba_dict_test[m])
-        y_test_pred = weighted_ensemble.predict_proba(b)
+        weighted_ensemble.fit(predictions=pred_proba_dict_val, labels=y_val)
+        y_test_pred = weighted_ensemble.predict_proba(pred_proba_dict_test)
         y_test = y_test.fillna(-1)
         err = eval_metric._optimum - eval_metric(y_test, y_test_pred)  # FIXME: proba or pred, figure out
 

--- a/autogluon_zeroshot/simulation/simulation_context.py
+++ b/autogluon_zeroshot/simulation/simulation_context.py
@@ -184,14 +184,10 @@ class ZeroshotSimulatorContext:
         # NOTE: This file is BIG (17 GB)
         cls = TabularPicklePerTaskPredictions if lazy_format else TabularPicklePredictions
         zeroshot_pred_proba = cls.load(path_pred_proba)
-        # print('Loading zeroshot successful!')
-        #
-        # zeroshot_pred_proba = {k: v for k, v in zeroshot_pred_proba.items() if k in self.dataset_to_tid_dict}
-        # zeroshot_pred_proba = {self.dataset_name_to_tid_dict[self.dataset_to_tid_dict[k]]: v for k, v in
-        #                        zeroshot_pred_proba.items()}
         for k in zeroshot_pred_proba.datasets:
             if k not in self.dataset_to_tid_dict:
                 zeroshot_pred_proba.remove_dataset(k)
+        # rename dataset to dataset-ids
         zeroshot_pred_proba.rename_datasets({
             k: self.dataset_name_to_tid_dict[self.dataset_to_tid_dict[k]]
             for k in zeroshot_pred_proba.datasets

--- a/autogluon_zeroshot/simulation/simulation_context.py
+++ b/autogluon_zeroshot/simulation/simulation_context.py
@@ -204,12 +204,9 @@ class ZeroshotSimulatorContext:
         new_filename = Paths.all_v3_results_root / "zeroshot_pred_per_task"
         if not new_filename.exists() or override_if_already_exists:
             print(f"lazy format folder {new_filename} not found or override option set to True, "
-                  f"converting to lazy format.")
-            with catchtime("load"):
-                preds = TabularPicklePredictions.load(str(Paths.all_v3_results_root / filename))
-
-            with catchtime("convert"):
-                preds_npy = TabularPicklePerTaskPredictions.from_dict(preds.pred_dict, output_dir=str(new_filename))
+                  f"converting to lazy format. It should take less than 3 min.")
+            preds = TabularPicklePredictions.load(str(Paths.all_v3_results_root / "zeroshot_pred_proba_2022_10_13_zs.pkl"))
+            preds_npy = TabularPicklePerTaskPredictions.from_dict(preds.pred_dict, output_dir=str(new_filename))
 
     @staticmethod
     def minimize_memory_zeroshot_pred_proba(zeroshot_pred_proba: dict, configs: list):

--- a/autogluon_zeroshot/simulation/simulation_context.py
+++ b/autogluon_zeroshot/simulation/simulation_context.py
@@ -187,9 +187,9 @@ class ZeroshotSimulatorContext:
         for k in zeroshot_pred_proba.datasets:
             if k not in self.dataset_to_tid_dict:
                 zeroshot_pred_proba.remove_dataset(k)
-        # rename dataset to dataset-ids
+        # rename dataset to dataset-ids, eg. 'abalone' is mapped to 359944.0
         zeroshot_pred_proba.rename_datasets({
-            k: self.dataset_name_to_tid_dict[self.dataset_to_tid_dict[k]]
+            k: self.dataset_to_tid_dict[k]
             for k in zeroshot_pred_proba.datasets
         })
         return zeroshot_pred_proba

--- a/autogluon_zeroshot/simulation/synetune_wrapper/synetune_search.py
+++ b/autogluon_zeroshot/simulation/synetune_wrapper/synetune_search.py
@@ -1,0 +1,118 @@
+import numpy as np
+from typing import Optional, List
+
+from syne_tune.backend.trial_status import Trial
+from syne_tune.optimizer.scheduler import TrialSuggestion, TrialScheduler
+
+
+class RandomSearch(TrialScheduler):
+    def __init__(self, models: List[dict], metric: str, num_base_models: int, train_datasets, test_datasets,
+                 num_folds: int, ensemble_size: int, initial_suggestions=None):
+        """Search configurations by random sampling."""
+        super(RandomSearch, self).__init__(config_space={
+            "configs": None,
+            "train_datasets": None,
+            "test_datasets": None,
+            "num_folds": None,
+            "ensemble_size": None,
+        })
+        self.metric = metric
+        self.models = models
+        self.num_base_models = num_base_models
+        self.train_datasets = train_datasets
+        self.test_datasets = test_datasets
+        self.num_folds = num_folds
+        self.ensemble_size = ensemble_size
+        self.mode = "min"
+        self.initial_suggestions = initial_suggestions if initial_suggestions is not None else []
+
+    def _suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
+        if len(self.initial_suggestions) > 0:
+            configs = self.initial_suggestions.pop()
+        else:
+            configs = [self.models[i] for i in np.random.permutation(len(self.models))[:self.num_base_models]]
+        config = {
+            "configs": configs,
+            "train_datasets": self.train_datasets,
+            "test_datasets": self.test_datasets,
+            "num_folds": self.num_folds,
+            "ensemble_size": self.ensemble_size,
+        }
+        return TrialSuggestion.start_suggestion(config)
+
+    def metric_names(self) -> List[str]:
+        return [self.metric]
+
+
+class LocalSearch(TrialScheduler):
+    def __init__(self, models: List[dict], metric: str, num_base_models: int, train_datasets, test_datasets,
+                 num_folds: int, ensemble_size: int, initial_suggestions=None):
+        """Search ensemble configurations by mutating the top configuration."""
+        super(LocalSearch, self).__init__(config_space={
+            "configs": None,
+            "train_datasets": None,
+            "test_datasets": None,
+            "num_folds": None,
+            "ensemble_size": None,
+        })
+        self.metric = metric
+        self.models = models
+        self.num_base_models = num_base_models
+        self.train_datasets = train_datasets
+        self.test_datasets = test_datasets
+        self.num_folds = num_folds
+        self.ensemble_size = ensemble_size
+        self.mode = "min"
+        self.initial_suggestions = initial_suggestions if initial_suggestions is not None else []
+        self.config_scores = {}
+
+    def _suggest(self, trial_id: int) -> Optional[TrialSuggestion]:
+        if len(self.initial_suggestions) > 0:
+            configs = self.initial_suggestions.pop()
+        elif len(self.config_scores) == 0:
+            # no config sampled yet, sample at random
+            configs = [self.models[i] for i in np.random.permutation(len(self.models))[:self.num_base_models]]
+        else:
+            configs = self.mutate_top_config()
+        config = {
+            "configs": configs,
+            "train_datasets": self.train_datasets,
+            "test_datasets": self.test_datasets,
+            "num_folds": self.num_folds,
+            "ensemble_size": self.ensemble_size,
+        }
+        self.config_scores[tuple(configs)] = None
+        return TrialSuggestion.start_suggestion(config)
+
+    def mutate_top_config(self):
+        # pick the best configuration and mutate it.
+        best_configs = sorted(self.config_scores.items(), key=lambda x: x[1] if x[1] else np.inf)
+        best_configs = [x[0] for x in best_configs]
+        best_config = list(best_configs[0])
+
+        # mutate the configuration until one that was not seen before is obtained
+        def mutate(models):
+            res = models.copy()
+            res[np.random.randint(0, len(models))] = str(np.random.choice(self.models))
+            return res
+        num_tries = 10
+        for i in range(num_tries):
+            new_models = mutate(best_config)
+            if tuple(new_models) not in self.config_scores:
+                break
+        if i == num_tries:
+            # in the case where we could not obtain a new configuration in `num_tries`, sample one at random
+            new_models = [self.models[i] for i in np.random.permutation(len(self.models))[:self.num_base_models]]
+
+        return new_models
+
+    def on_trial_result(self, trial: Trial, result: dict) -> str:
+        self.config_scores[tuple(trial.config['configs'])] = result[self.metric]
+
+    def metric_names(self) -> List[str]:
+        return [self.metric]
+
+
+
+
+

--- a/autogluon_zeroshot/simulation/tabular_predictions.py
+++ b/autogluon_zeroshot/simulation/tabular_predictions.py
@@ -1,0 +1,312 @@
+import json
+import shutil
+from typing import List, Dict, Tuple
+
+import numpy as np
+from pathlib import Path
+
+from autogluon.common.loaders import load_pkl
+from autogluon.common.savers.save_pkl import save
+
+# dictionary mapping dataset to fold to split to config name to predictions
+TabularPredictionsDict = Dict[str, Dict[int, Dict[str, Dict[str, np.array]]]]
+
+
+class TabularModelPredictions:
+
+    def score(self, dataset: str, fold: int, splits: List[str] = None, models: List[str] = None) -> List[np.array]:
+        """
+        :param dataset:
+        :param fold:
+        :param splits: split to consider values must be in 'val' or 'test'
+        :param models: list of models to be evaluated, by default uses all models available
+        :return: for each split, a tensor with shape (num_models, num_points) for regression and
+        (num_models, num_points, num_classes) for classification.
+        """
+        if splits is None:
+            splits = ['val', 'test']
+        for split in splits:
+            assert split in ['val', 'test']
+        return self._score(dataset, fold, splits, models)
+
+    def models_available_per_dataset(self, dataset: str, fold: int) -> List[str]:
+        """:returns the models available on both validation and test splits"""
+        raise NotImplementedError()
+
+    @property
+    def models(self) -> List[str]:
+        raise NotImplementedError()
+
+    @property
+    def datasets(self) -> List[str]:
+        raise NotImplementedError()
+
+    @property
+    def folds(self) -> List[int]:
+        raise NotImplementedError()
+
+    @classmethod
+    def from_dict(cls, pred_dict: TabularPredictionsDict, output_dir: str = None):
+        """
+        :param pred_dict: dictionary mapping dataset to fold to split to config name to predictions
+        :return:
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def load(cls, filename: str):
+        raise NotImplementedError()
+
+    def save(self, filename: str):
+        raise NotImplementedError()
+
+    def _score(self, dataset: str, fold: int, splits: List[str] = None, models: List[str] = None) -> List[np.array]:
+        raise NotImplementedError()
+
+
+class TabularPicklePredictions(TabularModelPredictions):
+    def __init__(self, pred_dict: TabularPredictionsDict):
+        self.pred_dict = pred_dict
+
+    @classmethod
+    def load(cls, filename: str):
+        return cls(pred_dict=load_pkl.load(filename))
+
+    @classmethod
+    def from_dict(cls, pred_dict: TabularPredictionsDict, output_dir: str = None):
+        return cls(pred_dict=pred_dict)
+
+    def save(self, filename: str):
+        save(filename, self.pred_dict)
+
+    def _score(self, dataset: str, fold: int, splits: List[str] = None, models: List[str] = None) -> List[np.array]:
+        def get_split(split, models):
+            split_key = 'pred_proba_dict_test' if split == "test" else 'pred_proba_dict_val'
+            model_results = self.pred_dict[dataset][fold][split_key]
+            if models is None:
+                models = model_results.keys()
+            return np.array([model_results[model] for model in models])
+
+        return [get_split(split, models) for split in splits]
+
+    def models_available_per_dataset(self, dataset: str, fold: int = 0) -> List[str]:
+        models = []
+        for fold in self.folds:
+            for split in ["pred_proba_dict_val", "pred_proba_dict_test"]:
+                models.append(set(self.pred_dict[dataset][fold][split].keys()))
+        # returns models that appears in all lists, eg that are available for all folds and splits
+        return list(set.intersection(*map(set, models)))
+
+    @property
+    def models(self) -> List[str]:
+        models = []
+        for dataset in self.datasets:
+            for fold in self.folds:
+                for split in ["pred_proba_dict_val", "pred_proba_dict_test"]:
+                    models.append(set(self.pred_dict[dataset][fold][split].keys()))
+        # returns models that appears in all lists, eg that are available for all datasets, folds and splits
+        return list(set.intersection(*map(set, models)))
+
+    @property
+    def datasets(self) -> List[str]:
+        return list(self.pred_dict.keys())
+
+    @property
+    def folds(self) -> List[int]:
+        # todo we could assert that the same number of folds exists in all cases
+        first = next(iter(self.pred_dict.values()))
+        return list(first.keys())
+
+
+class TabularPicklePerTaskPredictions(TabularModelPredictions):
+    def __init__(self, dataset_to_models: Dict[str, List[str]], output_dir: str):
+        self.dataset_to_models = dataset_to_models
+        self.output_dir = Path(output_dir)
+        assert self.output_dir.is_dir()
+
+    def _score(self, dataset: str, fold: int, splits: List[str] = None, models: List[str] = None) -> List[np.array]:
+        pred_dict = self._load_dataset(dataset)
+        if models is None:
+            models = self.models_available_per_dataset(dataset, fold)
+
+        def get_split(split, models):
+            split_key = 'pred_proba_dict_test' if split == "test" else 'pred_proba_dict_val'
+            model_results = pred_dict[fold][split_key]
+            return np.array([model_results[model] for model in models])
+        return [get_split(split, models) for split in splits]
+
+    def _load_dataset(self, dataset: str) -> Dict:
+        filename = str(self.output_dir / f'{dataset}.pkl')
+        return load_pkl.load(filename)
+
+    @classmethod
+    def from_dict(cls, pred_dict: TabularPredictionsDict, output_dir: str = None):
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        pred_proba = TabularPicklePredictions.from_dict(pred_dict=pred_dict)
+        datasets = pred_proba.datasets
+        dataset_to_models = {
+            dataset: pred_proba.models_available_per_dataset(dataset)
+            for dataset in datasets
+        }
+        print(f"saving .pkl files in folder {output_dir}")
+        for dataset in datasets:
+            filename = str(output_dir / f'{dataset}.pkl')
+            print(filename)
+            save(filename, pred_dict[dataset])
+        cls._save_metadata(output_dir=output_dir, dataset_to_models=dataset_to_models)
+        return cls(dataset_to_models=dataset_to_models, output_dir=output_dir)
+
+    def save(self, output_dir: str):
+        print(f"saving into {output_dir}")
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        self._save_metadata(output_dir, self.dataset_to_models)
+        print(f"copy .pkl files from {self.output_dir} to {output_dir}")
+        for file in self.output_dir.glob("*.pkl"):
+            shutil.copyfile(file, output_dir / file.name)
+
+    @classmethod
+    def load(cls, filename: str):
+        filename = Path(filename)
+        metadata = cls._load_metadata(filename)
+        dataset_to_models = metadata["dataset_to_models"]
+
+        return cls(
+            dataset_to_models=dataset_to_models,
+            output_dir=filename,
+        )
+
+    def models_available_per_dataset(self, dataset: str, fold: int) -> List[str]:
+        return self.dataset_to_models[dataset]
+
+    @property
+    def datasets(self):
+        return list(self.dataset_to_models.keys())
+
+    @staticmethod
+    def _save_metadata(output_dir, dataset_to_models):
+        with open(output_dir / "metadata.json", "w") as f:
+            metadata = {
+                "dataset_to_models": dataset_to_models,
+            }
+            json.dump(metadata, f)
+
+    @staticmethod
+    def _load_metadata(output_dir):
+        with open(output_dir / "metadata.json", "r") as f:
+            return json.load(f)
+
+
+class TabularNpyPredictions(TabularModelPredictions):
+    def __init__(self, dataset_to_models: Dict[str, List[str]], output_dir: str):
+        self.dataset_to_models = dataset_to_models
+        self.output_dir = Path(output_dir)
+        assert self.output_dir.is_dir()
+
+    @classmethod
+    def from_dict(cls, pred_dict: TabularPredictionsDict, output_dir: str):
+        def _stack_and_slice(arrays):
+            num_points_splits = set([arr.shape[1] for arr in arrays])
+            if len(num_points_splits) > 1:
+                # some splits may have different number of points slice to uniform
+                min_num_points = min(num_points_splits)
+                print(
+                    f"Folds have different number of points ({num_points_splits}), keeping {min_num_points} in each fold.")
+                arrays = np.array([arr[:, :min_num_points, ...] for arr in arrays])
+                return np.stack(arrays)
+            else:
+                return np.stack(arrays)
+
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        pred_proba = TabularPicklePredictions.from_dict(pred_dict=pred_dict)
+        datasets = pred_proba.datasets
+        dataset_to_models = {
+            dataset: pred_proba.models_available_per_dataset(dataset)
+            for dataset in datasets
+        }
+        models = pred_proba.models
+        print(f"saving .npy files in folder {output_dir}")
+        for dataset in datasets:
+            filename = output_dir / f'{dataset}.npy'
+            print(filename)
+            folds = pred_proba.folds
+            with open(filename, 'wb') as f:
+                # two tensor with shape (num_models, output_dim) or (num_models,) if
+                # the problem is unidimensional
+                val_array = _stack_and_slice([
+                    pred_proba.score(dataset=dataset, fold=fold, splits=['val'], models=models)[0]
+                    for fold in folds
+                ])
+                test_array = _stack_and_slice([
+                    pred_proba.score(dataset=dataset, fold=fold, splits=['test'], models=models)[0]
+                    for fold in folds
+                ])
+                for arr in val_array, test_array:
+                    assert arr.shape[0] == len(folds)
+                    assert arr.shape[1] == len(models)
+                np.save(f, val_array.astype("float16"))
+                np.save(f, test_array.astype("float16"))
+        cls._save_metadata(output_dir=output_dir, dataset_to_models=dataset_to_models)
+        return cls(dataset_to_models=dataset_to_models, output_dir=output_dir)
+
+    def _load_dataset(self, dataset: str) -> Tuple[np.array, np.array]:
+        filename = self.output_dir / f'{dataset}.npy'
+        with open(filename, 'rb') as f:
+            val_array = np.load(f)
+            test_array = np.load(f)
+        return val_array, test_array
+
+    def _score(self, dataset: str, fold: int, splits: List[str] = None, models: List[str] = None) -> List[np.array]:
+        # two tensor with shape (num_folds, num_models, output_dim) or (num_folds, num_models,)
+        val_array, test_array = self._load_dataset(dataset)
+        split_dict = {
+            "val": val_array,
+            "test": test_array,
+        }
+        # tensors with shape (num_models, num_points, num_classes) for each split
+        return [split_dict[split][fold] for split in splits]
+
+    def save(self, output_dir: str):
+        print(f"saving into {output_dir}")
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        self._save_metadata(output_dir, self.dataset_to_models)
+        print(f"copy .npy files from {self.output_dir} to {output_dir}")
+        for file in self.output_dir.glob("*.npy"):
+            shutil.copyfile(file, output_dir / file.name)
+
+    @classmethod
+    def load(cls, filename: str):
+        # 1) load dataset to models in json
+        # 2) load .npy
+        filename = Path(filename)
+
+        metadata = cls._load_metadata(filename)
+        dataset_to_models = metadata["dataset_to_models"]
+
+        return cls(
+            dataset_to_models=dataset_to_models,
+            output_dir=filename,
+        )
+
+    def models_available_per_dataset(self, dataset: str, fold: int) -> List[str]:
+        return self.dataset_to_models[dataset]
+
+    @property
+    def datasets(self):
+        return list(self.dataset_to_models.keys())
+
+    @staticmethod
+    def _save_metadata(output_dir, dataset_to_models):
+        with open(output_dir / "metadata.json", "w") as f:
+            metadata = {
+                "dataset_to_models": dataset_to_models,
+            }
+            json.dump(metadata, f)
+
+    @staticmethod
+    def _load_metadata(output_dir):
+        with open(output_dir / "metadata.json", "r") as f:
+            return json.load(f)

--- a/autogluon_zeroshot/simulation/tabular_predictions.py
+++ b/autogluon_zeroshot/simulation/tabular_predictions.py
@@ -13,6 +13,9 @@ TabularPredictionsDict = Dict[str, Dict[int, Dict[str, Dict[str, np.array]]]]
 
 
 class TabularModelPredictions:
+    """
+    Class that allows to query offline predictions.
+    """
 
     def score(self, dataset: str, fold: int, splits: List[str] = None, models: List[str] = None) -> List[np.array]:
         """
@@ -27,6 +30,7 @@ class TabularModelPredictions:
             splits = ['val', 'test']
         for split in splits:
             assert split in ['val', 'test']
+        assert models is None or len(models) > 0
         return self._score(dataset, fold, splits, models)
 
     def models_available_per_dataset(self, dataset: str, fold: int) -> List[str]:
@@ -214,120 +218,6 @@ class TabularPicklePerTaskPredictions(TabularModelPredictions):
         for key in rename_dict:
             assert key in self.datasets
         self.rename_dict_inv = {v: k for k, v in rename_dict.items()}
-
-    @staticmethod
-    def _save_metadata(output_dir, dataset_to_models):
-        with open(output_dir / "metadata.json", "w") as f:
-            metadata = {
-                "dataset_to_models": dataset_to_models,
-            }
-            json.dump(metadata, f)
-
-    @staticmethod
-    def _load_metadata(output_dir):
-        with open(output_dir / "metadata.json", "r") as f:
-            return json.load(f)
-
-
-class TabularNpyPredictions(TabularModelPredictions):
-    def __init__(self, dataset_to_models: Dict[str, List[str]], output_dir: str):
-        self.dataset_to_models = dataset_to_models
-        self.output_dir = Path(output_dir)
-        assert self.output_dir.is_dir()
-
-    @classmethod
-    def from_dict(cls, pred_dict: TabularPredictionsDict, output_dir: str):
-        def _stack_and_slice(arrays):
-            num_points_splits = set([arr.shape[1] for arr in arrays])
-            if len(num_points_splits) > 1:
-                # some splits may have different number of points slice to uniform
-                min_num_points = min(num_points_splits)
-                print(
-                    f"Folds have different number of points ({num_points_splits}), keeping {min_num_points} in each fold.")
-                arrays = np.array([arr[:, :min_num_points, ...] for arr in arrays])
-                return np.stack(arrays)
-            else:
-                return np.stack(arrays)
-
-        output_dir = Path(output_dir)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        pred_proba = TabularPicklePredictions.from_dict(pred_dict=pred_dict)
-        datasets = pred_proba.datasets
-        dataset_to_models = {
-            dataset: pred_proba.models_available_per_dataset(dataset)
-            for dataset in datasets
-        }
-        models = pred_proba.models
-        print(f"saving .npy files in folder {output_dir}")
-        for dataset in datasets:
-            filename = output_dir / f'{dataset}.npy'
-            print(filename)
-            folds = pred_proba.folds
-            with open(filename, 'wb') as f:
-                # two tensor with shape (num_models, output_dim) or (num_models,) if
-                # the problem is unidimensional
-                val_array = _stack_and_slice([
-                    pred_proba.score(dataset=dataset, fold=fold, splits=['val'], models=models)[0]
-                    for fold in folds
-                ])
-                test_array = _stack_and_slice([
-                    pred_proba.score(dataset=dataset, fold=fold, splits=['test'], models=models)[0]
-                    for fold in folds
-                ])
-                for arr in val_array, test_array:
-                    assert arr.shape[0] == len(folds)
-                    assert arr.shape[1] == len(models)
-                np.save(f, val_array.astype("float16"))
-                np.save(f, test_array.astype("float16"))
-        cls._save_metadata(output_dir=output_dir, dataset_to_models=dataset_to_models)
-        return cls(dataset_to_models=dataset_to_models, output_dir=output_dir)
-
-    def _load_dataset(self, dataset: str) -> Tuple[np.array, np.array]:
-        filename = self.output_dir / f'{dataset}.npy'
-        with open(filename, 'rb') as f:
-            val_array = np.load(f)
-            test_array = np.load(f)
-        return val_array, test_array
-
-    def _score(self, dataset: str, fold: int, splits: List[str] = None, models: List[str] = None) -> List[np.array]:
-        # two tensor with shape (num_folds, num_models, output_dim) or (num_folds, num_models,)
-        val_array, test_array = self._load_dataset(dataset)
-        split_dict = {
-            "val": val_array,
-            "test": test_array,
-        }
-        # tensors with shape (num_models, num_points, num_classes) for each split
-        return [split_dict[split][fold] for split in splits]
-
-    def save(self, output_dir: str):
-        print(f"saving into {output_dir}")
-        output_dir = Path(output_dir)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        self._save_metadata(output_dir, self.dataset_to_models)
-        print(f"copy .npy files from {self.output_dir} to {output_dir}")
-        for file in self.output_dir.glob("*.npy"):
-            shutil.copyfile(file, output_dir / file.name)
-
-    @classmethod
-    def load(cls, filename: str):
-        # 1) load dataset to models in json
-        # 2) load .npy
-        filename = Path(filename)
-
-        metadata = cls._load_metadata(filename)
-        dataset_to_models = metadata["dataset_to_models"]
-
-        return cls(
-            dataset_to_models=dataset_to_models,
-            output_dir=filename,
-        )
-
-    def models_available_per_dataset(self, dataset: str, fold: int) -> List[str]:
-        return self.dataset_to_models[dataset]
-
-    @property
-    def datasets(self):
-        return list(self.dataset_to_models.keys())
 
     @staticmethod
     def _save_metadata(output_dir, dataset_to_models):

--- a/autogluon_zeroshot/simulation/tabular_predictions.py
+++ b/autogluon_zeroshot/simulation/tabular_predictions.py
@@ -120,6 +120,12 @@ class TabularPicklePredictions(TabularModelPredictions):
 
 class TabularPicklePerTaskPredictions(TabularModelPredictions):
     def __init__(self, dataset_to_models: Dict[str, List[str]], output_dir: str):
+        """
+        Stores on pickle per task and load data in a lazy fashion which allows to reduce significantly the memory
+        footprint.
+        :param dataset_to_models:
+        :param output_dir:
+        """
         self.dataset_to_models = dataset_to_models
         self.output_dir = Path(output_dir)
         assert self.output_dir.is_dir()

--- a/autogluon_zeroshot/utils/__init__.py
+++ b/autogluon_zeroshot/utils/__init__.py
@@ -1,0 +1,12 @@
+from contextlib import contextmanager
+from time import perf_counter
+
+
+@contextmanager
+def catchtime(name: str) -> float:
+    start = perf_counter()
+    try:
+        print(f"start: {name}")
+        yield lambda: perf_counter() - start
+    finally:
+        print(f"Time for {name}: {perf_counter() - start:.4f} secs")

--- a/scripts/method_comparison/README.md
+++ b/scripts/method_comparison/README.md
@@ -1,0 +1,17 @@
+# Method comparison
+
+The setup is the same as for other experiments, you will just need in addition to install syne-tune to be able to run
+searchers:
+
+```
+pip install syne-tune[extra]
+```
+
+Then you can run:
+* `run_method_comparison.py`: to generate evaluations of different search strategies (all, random, local, zeroshot, zeroshot-ensemble)
+* `plot_results_comparison.py`: to get a table with the results
+
+Note that this assumes that you have obtained large files by running `run_download_zeroshot_pred_proba.py`, also the 
+first time you call run `run_method_comparison.py` a conversion of `zeroshot_pred_proba_2022_10_13_zs.pkl` will be 
+triggered to generate `zeroshot_pred_per_task` which is a format allowing for lazy evaluation (loading task data
+on the fly).

--- a/scripts/method_comparison/plot_results_comparison.py
+++ b/scripts/method_comparison/plot_results_comparison.py
@@ -1,0 +1,29 @@
+import os
+from argparse import ArgumentParser
+
+import pandas as pd
+
+from autogluon_zeroshot.loaders import Paths
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--expname", type=str,
+        help="The name that you set or that was generated when you evaluated \"run_method_comparison.py\""
+    )
+    input_args, _ = parser.parse_known_args()
+
+    expname = input_args.expname
+
+    csv_filename = Paths.results_root / f"{expname}.csv"
+
+    df_results = pd.read_csv(csv_filename).drop("selected_configs", axis=1)
+
+    print(df_results.pivot_table(values=["train-score", "test-score"], columns="fold", index='searcher').to_string())
+
+    df_results.groupby("fold").mean()
+
+    print(df_results.groupby("searcher").agg(['mean', 'std'])[['train-score', 'test-score']].to_string(float_format="%.2f"))
+
+

--- a/scripts/method_comparison/run_evaluate_config_lazy.py
+++ b/scripts/method_comparison/run_evaluate_config_lazy.py
@@ -1,0 +1,22 @@
+# File to check that we get the same error as run_evaluate_config.py. It can be removed.
+from autogluon_zeroshot.contexts.context_2022_10_13 import load_context_2022_10_13
+from autogluon_zeroshot.utils import catchtime
+from scripts.evaluate_ensemble import evaluate_ensemble
+
+if __name__ == '__main__':
+    with catchtime("eval"):
+        with catchtime("load"):
+            zsc, configs_full, zeroshot_pred_proba, zeroshot_gt = load_context_2022_10_13(load_zeroshot_pred_proba=False)
+        configs = zsc.get_configs()
+        datasets = zsc.get_dataset_folds()
+
+        train_error, _ = evaluate_ensemble(
+            configs=configs,
+            train_datasets=datasets,
+            test_datasets=[],
+            ensemble_size=100,
+        )
+
+        # With ensemble_size=100 610 datasets, 608 configs, I get
+        #  Final Score: 3.8311475409836064
+        print(f'Final Score: {train_error, _}')

--- a/scripts/run_download_zeroshot_pred_proba.py
+++ b/scripts/run_download_zeroshot_pred_proba.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from autogluon.common.loaders import load_pkl
 from autogluon.common.savers import save_pkl
-
+from autogluon_zeroshot.loaders import Paths
 
 if __name__ == '__main__':
     path_prefix = 's3://automl-benchmark-ag/aggregated/ec2/2022_10_13_zs/'
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     zeroshot_gt = load_pkl.load(path_gt)
     zeroshot_pred_proba = load_pkl.load(path_pred_proba)
 
-    save_path = Path(__file__).parent.parent / 'data' / 'results' / 'all_v3'
+    save_path = Paths.all_v3_results_root
 
     save_pkl.save(path=str(save_path / path_gt_name), object=zeroshot_gt)
     save_pkl.save(path=str(save_path / path_pred_proba_name), object=zeroshot_pred_proba)

--- a/scripts/run_evaluate_config.py
+++ b/scripts/run_evaluate_config.py
@@ -1,35 +1,35 @@
 
 from autogluon_zeroshot.simulation.ensemble_selection_config_scorer import EnsembleSelectionConfigScorer
 from autogluon_zeroshot.contexts.context_2022_10_13 import load_context_2022_10_13
-
+from autogluon_zeroshot.utils import catchtime
 
 if __name__ == '__main__':
-    zsc, configs_full, zeroshot_pred_proba, zeroshot_gt = load_context_2022_10_13(load_zeroshot_pred_proba=True)
-    zsc.print_info()
+    with catchtime("eval config"):
+        zsc, configs_full, zeroshot_pred_proba, zeroshot_gt = load_context_2022_10_13(load_zeroshot_pred_proba=True)
+        zsc.print_info()
 
-    # NOTE: For speed of simulation, it is recommended backend='ray'
-    #  If 'ray' isn't available, then specify 'native'.
-    backend = 'ray'
+        # NOTE: For speed of simulation, it is recommended backend='ray'
+        #  If 'ray' isn't available, then specify 'native'.
+        backend = 'ray'
 
-    # Evaluate when using all configs
-    configs = zsc.get_configs()
-    if configs is not None:
-        zeroshot_pred_proba.pred_dict = zsc.minimize_memory_zeroshot_pred_proba(
-            zeroshot_pred_proba=zeroshot_pred_proba.pred_dict,
-            configs=configs
+        # Evaluate when using all configs
+        configs = zsc.get_configs()
+        if configs is not None:
+            zeroshot_pred_proba.pred_dict = zsc.minimize_memory_zeroshot_pred_proba(
+                zeroshot_pred_proba=zeroshot_pred_proba.pred_dict,
+                configs=configs
+            )
+        datasets = zsc.get_dataset_folds()
+        config_scorer = EnsembleSelectionConfigScorer.from_zsc(
+            datasets=datasets,
+            zeroshot_simulator_context=zsc,
+            zeroshot_gt=zeroshot_gt,
+            zeroshot_pred_proba=zeroshot_pred_proba,
+            ensemble_size=100,  # 100 is better, but 10 allows to simulate 10x faster
         )
-    datasets = zsc.get_dataset_folds()
 
-    config_scorer = EnsembleSelectionConfigScorer.from_zsc(
-        datasets=datasets,
-        zeroshot_simulator_context=zsc,
-        zeroshot_gt=zeroshot_gt,
-        zeroshot_pred_proba=zeroshot_pred_proba,
-        ensemble_size=100,  # 100 is better, but 10 allows to simulate 10x faster
-    )
+        score = config_scorer.score(configs, backend=backend)
 
-    score = config_scorer.score(configs, backend=backend)
-
-    # With ensemble_size=100 610 datasets, 608 configs, I get
-    #  Final Score: 3.8278688524590163
-    print(f'Final Score: {score}')
+        # With ensemble_size=100 610 datasets, 608 configs, I get
+        #  Final Score: 3.8278688524590163
+        print(f'Final Score: {score}')

--- a/scripts/run_evaluate_config.py
+++ b/scripts/run_evaluate_config.py
@@ -14,8 +14,10 @@ if __name__ == '__main__':
     # Evaluate when using all configs
     configs = zsc.get_configs()
     if configs is not None:
-        zeroshot_pred_proba = zsc.minimize_memory_zeroshot_pred_proba(zeroshot_pred_proba=zeroshot_pred_proba,
-                                                                      configs=configs)
+        zeroshot_pred_proba.pred_dict = zsc.minimize_memory_zeroshot_pred_proba(
+            zeroshot_pred_proba=zeroshot_pred_proba.pred_dict,
+            configs=configs
+        )
     datasets = zsc.get_dataset_folds()
 
     config_scorer = EnsembleSelectionConfigScorer.from_zsc(

--- a/scripts/run_method_comparison.py
+++ b/scripts/run_method_comparison.py
@@ -1,0 +1,278 @@
+"""
+Compare different methods that searches for ensemble configurations given offline evaluations.
+Several strategies are available:
+* all: evaluate the ensemble performance when using all model available
+* zeroshot: evaluate the ensemble performance of zeroshot configurations
+* zeroshot-ensemble: evaluate the ensemble performance of zeroshot configurations and when scoring list of models with
+their ensemble performance
+* randomsearch: performs a randomsearch after initializing the initial configuration with zeroshot
+* localsearch: performs a localsearch after initializing the initial configuration with zeroshot. For each new
+candidate, the best current configuration is mutated.
+
+For random/local search, the search is done asynchronously with multiple workers.
+
+Example:
+PYTHONPATH=. python scripts/run_method_comparison.py --setting slow --n_workers 64
+"""
+import string
+from argparse import ArgumentParser
+from dataclasses import dataclass
+import random
+from typing import List
+
+import numpy as np
+import logging
+from pathlib import Path
+
+import pandas as pd
+from sklearn.model_selection import KFold
+from syne_tune import Tuner, StoppingCriterion
+from syne_tune.backend import LocalBackend
+from syne_tune.experiments import load_experiment
+
+from autogluon_zeroshot.contexts.context_2022_10_13 import load_context_2022_10_13, get_configs_small
+from autogluon_zeroshot.loaders import Paths
+from autogluon_zeroshot.simulation.config_generator import ZeroshotConfigGenerator
+from autogluon_zeroshot.simulation.ensemble_selection_config_scorer import EnsembleSelectionConfigScorer
+from autogluon_zeroshot.simulation.single_best_config_scorer import SingleBestConfigScorer
+from autogluon_zeroshot.simulation.synetune_wrapper.synetune_search import RandomSearch, LocalSearch
+from autogluon_zeroshot.utils import catchtime
+from scripts.evaluate_ensemble import evaluate_ensemble
+
+logging.getLogger().setLevel(logging.INFO)
+
+
+def compute_zeroshot(models: List[str], datasets: List[str], ensemble_score: bool = False) -> List[str]:
+    """evaluate the performance of a list of configurations with Caruana ensembles on the provided datasets"""
+    zsc, configs_full, zeroshot_pred_proba, zeroshot_gt = load_context_2022_10_13(load_zeroshot_pred_proba=ensemble_score)
+    dataset_ids = [zsc.dataset_to_tid_dict[k] for k in datasets]
+    if ensemble_score:
+        config_scorer = EnsembleSelectionConfigScorer.from_zsc(
+            zeroshot_simulator_context=zsc,
+            datasets=dataset_ids,
+            zeroshot_gt=zeroshot_gt,
+            zeroshot_pred_proba=zeroshot_pred_proba,
+            ensemble_size=10,
+        )
+    else:
+        config_scorer = SingleBestConfigScorer.from_zsc(
+            zeroshot_simulator_context=zsc,
+            datasets=dataset_ids,
+        )
+    zs_config_generator = ZeroshotConfigGenerator(
+        config_scorer=config_scorer,
+        configs=models,
+        backend="ray",
+    )
+    zeroshot_configs = zs_config_generator.select_zeroshot_configs(10, removal_stage=False)
+    return zeroshot_configs
+
+
+def learn_ensemble_configuration(
+        train_datasets,
+        test_datasets,
+        models,
+        num_folds,
+        ensemble_size,
+        num_base_models,
+        max_wallclock_time,
+        n_workers,
+        max_num_trials_completed,
+        name,
+        searcher,
+):
+    assert searcher in ["randomsearch", "localsearch", "all", "zeroshot", "zeroshot-ensemble"]
+
+    print(searcher)
+    if searcher in ["randomsearch", "localsearch"]:
+        synetune_logger = logging.getLogger("syne_tune")
+        synetune_logger.setLevel(logging.WARNING)
+
+        with catchtime("Compute zeroshot config to initialize local search"):
+            zs_config = compute_zeroshot(models=models, datasets=train_datasets, ensemble_score=False)
+        searcher_cls = LocalSearch if searcher == "localsearch" else RandomSearch
+
+        scheduler = searcher_cls(
+            models=models,
+            metric='train_error',
+            num_base_models=num_base_models,
+            train_datasets=train_datasets,
+            # Important note, we pass the test datasets for benchmarking purposes though but they are not used by the
+            # searcher alternatively, an empty list can be passed but then test errors cannot be analyzed over time
+            test_datasets=test_datasets,
+            num_folds=num_folds,
+            ensemble_size=ensemble_size,
+            initial_suggestions=[zs_config[:num_base_models]],
+        )
+
+        tuner = Tuner(
+            trial_backend=LocalBackend(entry_point=Path(__file__).parent / 'evaluate_ensemble.py'),
+            scheduler=scheduler,
+            stop_criterion=StoppingCriterion(
+                max_wallclock_time=max_wallclock_time,
+                max_num_trials_completed=max_num_trials_completed
+            ),
+            n_workers=n_workers,
+            tuner_name=name,
+            metadata={"searcher": searcher}
+        )
+        tuner.run()
+
+        tuning_experiment = load_experiment(tuner.name)
+        # tuning_experiment.plot()
+
+        print(tuning_experiment)
+
+        print(f"best result found: {tuning_experiment.best_config()}")
+        best_config_dict = eval(tuning_experiment.best_config()['config_configs'])
+
+    elif searcher == "zeroshot":
+        with catchtime("Compute zeroshot config to initialize local search"):
+            best_config_dict = compute_zeroshot(models=models, datasets=train_datasets, ensemble_score=False)
+    elif searcher == "zeroshot-ensemble":
+        with catchtime("Compute zeroshot config to initialize local search"):
+            best_config_dict = compute_zeroshot(models=models, datasets=train_datasets, ensemble_score=True)
+    elif searcher == "all":
+        best_config_dict = models
+
+    train_error, test_error = evaluate_ensemble(
+        configs=best_config_dict,
+        train_datasets=train_datasets,
+        test_datasets=test_datasets,
+        num_folds=10,
+        ensemble_size=ensemble_size,
+    )
+
+    return best_config_dict, train_error, test_error
+
+
+@dataclass
+class Arguments:
+    n_workers: int
+    n_splits: int
+    num_folds: int
+    ensemble_size: int
+    max_wallclock_time: float
+    num_base_models: int
+    searchers: List[str]
+    max_num_trials_completed: int = 10000
+
+
+def random_string(length: int) -> str:
+    pool = string.ascii_letters + string.digits
+    return "".join(random.choice(pool) for _ in range(length))
+
+
+def get_setting(setting):
+    if setting == "fast":
+        return Arguments(
+            n_splits=1,
+            num_folds=1,
+            ensemble_size=20,
+            max_wallclock_time=600,
+            max_num_trials_completed=4,
+            num_base_models=4,
+            n_workers=input_args.n_workers,
+            searchers=['localsearch'],
+        )
+    elif setting == "medium":
+        return Arguments(
+            n_splits=2,
+            num_folds=5,
+            ensemble_size=20,
+            max_wallclock_time=600,
+            # max_num_trials_completed=100,
+            num_base_models=10,
+            n_workers=input_args.n_workers,
+            searchers=['randomsearch', 'localsearch'],
+        )
+    elif setting == "slow":
+        return Arguments(
+            n_splits=5,
+            num_folds=10,
+            ensemble_size=20,
+            max_wallclock_time=1200,
+            max_num_trials_completed=100000,
+            num_base_models=10,
+            n_workers=input_args.n_workers,
+            searchers=[
+                "zeroshot",
+                "zeroshot-ensemble",
+                "all",
+                "randomsearch",
+                "localsearch",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--setting", type=str, default="fast")
+    parser.add_argument("--n_workers", type=int, default=8)
+    parser.add_argument("--expname", type=str)
+    input_args, _ = parser.parse_known_args()
+
+    if input_args.expname is None:
+        expname = random_string(5)
+    else:
+        expname = input_args.expname
+
+    args = get_setting(setting=input_args.setting)
+    print(f"Running experiment {expname} with {input_args.setting} settings: {args}")
+    # TODO, for now we are using datanames rather than id, we may want to use dataset-id to have the same splits
+    #  as the other zeroshot simulation script
+    all_datasets = [
+        'abalone', 'ada', 'adult', 'Amazon_employee_access', 'arcene', 'Australian', 'Bioresponse', 'black_friday',
+        'blood-transfusion-service-center', 'boston', 'Brazilian_houses', 'car', 'christine', 'churn',
+        'Click_prediction_small', 'cmc', 'cnae-9', 'colleges', 'credit-g', 'diamonds', 'dna', 'elevators', 'eucalyptus',
+        'first-order-theorem-proving', 'GesturePhaseSegmentationProcessed', 'gina', 'house_prices_nominal',
+        'house_sales',
+        'Internet-Advertisements', 'jannis', 'jasmine', 'jungle_chess_2pcs_raw_endgame_complete', 'kc1', 'kick',
+        'madeline',
+        'Mercedes_Benz_Greener_Manufacturing', 'MIP-2016-regression', 'Moneyball', 'numerai28_6', 'ozone-level-8hr',
+        'PhishingWebsites', 'phoneme', 'pol', 'QSAR-TID-10980', 'QSAR-TID-11', 'quake', 'SAT11-HAND-runtime-regression',
+        'Satellite', 'segment', 'sensory', 'shuttle', 'socmob', 'space_ga', 'steel-plates-fault', 'sylvine', 'tecator',
+        'us_crime', 'vehicle', 'wilt', 'wine_quality', 'yprop_4_1']
+    all_datasets = np.array(all_datasets)
+    np.random.shuffle(all_datasets)
+    models = get_configs_small()
+    if args.n_splits == 1:
+        indices = np.arange(len(all_datasets))
+        splits = [(indices[:len(indices) // 2], indices[len(indices) // 2:])]
+    else:
+        kf = KFold(n_splits=args.n_splits, random_state=0, shuffle=True)
+        splits = kf.split(all_datasets)
+        fold_results = []
+    results = []
+    for i, (train_index, test_index) in enumerate(splits):
+        for searcher in args.searchers:
+            with catchtime(f'****Fitting method {searcher} on fold {i + 1}****'):
+                train_datasets = list(all_datasets[train_index])
+                test_datasets = list(all_datasets[test_index])
+
+                best_config, train_error, test_error = learn_ensemble_configuration(
+                    train_datasets=train_datasets,
+                    test_datasets=test_datasets,
+                    models=models,
+                    num_folds=args.num_folds,
+                    ensemble_size=args.ensemble_size,
+                    num_base_models=args.num_base_models,
+                    max_wallclock_time=args.max_wallclock_time,
+                    n_workers=args.n_workers,
+                    max_num_trials_completed=args.max_num_trials_completed,
+                    searcher=searcher,
+                    name=f"{expname}-fold-{i}-{searcher}"
+                )
+                print(f"best config found: {best_config}")
+                print(f"train/test error of best config found: {train_error}/{test_error}")
+                results.append({
+                    'fold': i + 1,
+                    'train-score': train_error,
+                    'test-score': test_error,
+                    'selected_configs': best_config,
+                    'searcher': searcher,
+                })
+                csv_filename = Paths.results_root / f"{expname}.csv"
+                print(f"update results in {csv_filename}")
+                pd.DataFrame(results).to_csv(csv_filename, index=False)
+    print(results)

--- a/scripts/run_simulate_zs_ensemble.py
+++ b/scripts/run_simulate_zs_ensemble.py
@@ -1,3 +1,5 @@
+import pickle
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -5,12 +7,15 @@ import numpy as np
 from autogluon.common.savers import save_pkl
 
 from autogluon_zeroshot.simulation.ensemble_selection_config_scorer import EnsembleSelectionConfigScorer
-from autogluon_zeroshot.contexts.context_2022_10_13 import load_context_2022_10_13, get_configs_default, get_configs_small
+from autogluon_zeroshot.contexts.context_2022_10_13 import load_context_2022_10_13, get_configs_default, \
+    get_configs_small
 from autogluon_zeroshot.simulation.sim_runner import run_zs_simulation
 
-
 if __name__ == '__main__':
-    zsc, configs_full, zeroshot_pred_proba, zeroshot_gt = load_context_2022_10_13(load_zeroshot_pred_proba=True)
+    zsc, configs_full, zeroshot_pred_proba, zeroshot_gt = load_context_2022_10_13(
+        load_zeroshot_pred_proba=True,
+        lazy_format=False,
+    )
     zsc.print_info()
 
     # NOTE: For speed of simulation, it is recommended backend='ray'
@@ -19,8 +24,11 @@ if __name__ == '__main__':
 
     configs = get_configs_small()
     if configs is not None:
-        zeroshot_pred_proba = zsc.minimize_memory_zeroshot_pred_proba(zeroshot_pred_proba=zeroshot_pred_proba,
-                                                                      configs=configs)
+        zeroshot_pred_proba.pred_dict = zsc.minimize_memory_zeroshot_pred_proba(
+            zeroshot_pred_proba=zeroshot_pred_proba.pred_dict,
+            configs=configs
+        )
+
     score_total = 0
     len_datasets_total = 0
     results_total = []
@@ -47,7 +55,7 @@ if __name__ == '__main__':
         )
         score = np.mean([r['score'] for r in results])
         print(f'{problem_type}: {score} | {len_datasets}')
-        score_total += score*len_datasets
+        score_total += score * len_datasets
         results_total += results
     score_total = score_total / len_datasets_total
     print(f'Final Score: {score_total}')

--- a/tst/test_tabular_predictions.py
+++ b/tst/test_tabular_predictions.py
@@ -1,0 +1,97 @@
+import tempfile
+
+from math import prod
+from typing import List
+
+import numpy as np
+from pathlib import Path
+
+import pytest
+
+from autogluon_zeroshot.loaders import Paths
+from autogluon_zeroshot.utils import catchtime
+from autogluon_zeroshot.simulation.tabular_predictions import TabularPicklePredictions, TabularPredictionsDict, \
+    TabularNpyPredictions, TabularPicklePerTaskPredictions
+
+
+def test_real_data():
+    with catchtime("load"):
+        preds = TabularPicklePredictions.load(str(Paths.all_v3_results_root / "zeroshot_pred_proba_small.pkl"))
+
+    dataset = next(iter(preds.pred_dict.keys()))
+    models = preds.models_available_per_dataset(dataset=dataset, fold=2)
+    for model in ['CatBoost_c1', 'ExtraTrees_c1', 'ExtraTrees_r1', 'KNeighbors_c1', 'LightGBM_c2', 'LightGBM_r23',
+                  'NeuralNetFastAI_c1', 'RandomForest_r9']:
+        assert model in models
+    assert len(models) == 660
+    scores = preds.score(dataset=dataset, fold=2, splits=["test"])[0]
+    num_points = 51
+    assert scores.shape == (len(models), num_points)
+    assert np.isclose(scores.mean(), 21.437994)
+
+
+def generate_dummy(shape, models):
+    return {
+        model: np.arange(prod(shape)).reshape(shape)
+        for model in models
+    }
+
+
+def generate_artificial_dict(
+        num_folds: int,
+        models: List[str],
+        dataset_shapes={
+            "d1": ((20,), (50,)),
+            "d2": ((10,), (5,)),
+            "d3": ((4, 3), (8, 3)),
+        },
+):
+    # dictionary mapping dataset to fold to split to config name to predictions
+    pred_dict: TabularPredictionsDict = {
+        dataset: {
+            fold: {
+                "pred_proba_dict_val": generate_dummy(val_shape, models),
+                "pred_proba_dict_test": generate_dummy(test_shape, models),
+            }
+            for fold in range(num_folds)
+        }
+        for dataset, (val_shape, test_shape) in dataset_shapes.items()
+    }
+    return pred_dict
+
+
+# def check_synthetic_data_pickle(cls=TabularPicklePredictions):
+@pytest.mark.parametrize("cls", [TabularPicklePredictions, TabularNpyPredictions, TabularPicklePerTaskPredictions])
+def test_synthetic_data(cls):
+    num_models = 13
+    num_folds = 3
+    dataset_shapes = {
+        "d1": ((20,), (50,)),
+        "d2": ((10,), (5,)),
+        "d3": ((4, 3), (8, 3)),
+    }
+    models = [f"m_{i}" for i in range(num_models)]
+
+    pred_dict = generate_artificial_dict(num_folds, models, dataset_shapes)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+
+        # 1) construct pred proba from dictionary
+        pred_proba = cls.from_dict(pred_dict=pred_dict, output_dir=tmpdirname)
+        assert set(pred_proba.models_available_per_dataset(dataset="d1", fold=0)) == set(models)
+        filename = str(Path(tmpdirname) / "dummy")
+
+        # 2) save it and reload it
+        pred_proba.save(filename)
+        pred_proba = cls.load(filename)
+
+        # 3) checks that output is as expected after serializing/deserializing
+        assert pred_proba.datasets == list(dataset_shapes.keys())
+        for dataset, (val_shape, test_shape) in dataset_shapes.items():
+            print(dataset, val_shape, test_shape)
+            val_score, test_score = pred_proba.score(dataset=dataset, fold=2, models=models, splits=["val", "test"])
+            assert val_score.shape == tuple([num_models] + list(val_shape))
+            assert test_score.shape == tuple([num_models] + list(test_shape))
+            for i, model in enumerate(models):
+                assert np.allclose(val_score[i], generate_dummy(val_shape, models)[model])
+                assert np.allclose(test_score[i], generate_dummy(test_shape, models)[model])

--- a/tst/test_tabular_predictions.py
+++ b/tst/test_tabular_predictions.py
@@ -8,26 +8,8 @@ from pathlib import Path
 
 import pytest
 
-from autogluon_zeroshot.loaders import Paths
-from autogluon_zeroshot.utils import catchtime
 from autogluon_zeroshot.simulation.tabular_predictions import TabularPicklePredictions, TabularPredictionsDict, \
-    TabularNpyPredictions, TabularPicklePerTaskPredictions
-
-
-def test_real_data():
-    with catchtime("load"):
-        preds = TabularPicklePredictions.load(str(Paths.all_v3_results_root / "zeroshot_pred_proba_small.pkl"))
-
-    dataset = next(iter(preds.pred_dict.keys()))
-    models = preds.models_available_per_dataset(dataset=dataset, fold=2)
-    for model in ['CatBoost_c1', 'ExtraTrees_c1', 'ExtraTrees_r1', 'KNeighbors_c1', 'LightGBM_c2', 'LightGBM_r23',
-                  'NeuralNetFastAI_c1', 'RandomForest_r9']:
-        assert model in models
-    assert len(models) == 660
-    scores = preds.score(dataset=dataset, fold=2, splits=["test"])[0]
-    num_points = 51
-    assert scores.shape == (len(models), num_points)
-    assert np.isclose(scores.mean(), 21.437994)
+    TabularPicklePerTaskPredictions
 
 
 def generate_dummy(shape, models):
@@ -61,7 +43,7 @@ def generate_artificial_dict(
 
 
 # def check_synthetic_data_pickle(cls=TabularPicklePredictions):
-@pytest.mark.parametrize("cls", [TabularPicklePredictions, TabularNpyPredictions, TabularPicklePerTaskPredictions])
+@pytest.mark.parametrize("cls", [TabularPicklePredictions, TabularPicklePerTaskPredictions])
 def test_synthetic_data(cls):
     num_models = 13
     num_folds = 3


### PR DESCRIPTION
Changes:
* cosmetic: add `Paths.all_v3_results_root` and other to group path definitions of different files.
* add a class to represent tabular predictions with two implementations. The first one just wrap the pickle and have the same functionality as the dictionary that was used. The second provides a way to load data lazily which speeds up thing in some cases and is necessary with syne tune to avoid filling the memory with many workers.
* evaluation script to run multiple method comparison and plot results 

I hope the changes in the tabular predictions are not too invasive (and sorry for the bulk changes but I wanted to add files so that we can compare things more easily). I tried to minimize their impact as I needed to represent data in a different way. Happy to discuss if they are potential blockers that you anticipate.

PS: I obtain the same results as you reported in `run_evaluate_config.py` with the alternative format (except that the runtime is about 2x faster).