### PR TITLE
Add debugging, repeatedkfold, plots

### DIFF
--- a/autogluon_zeroshot/portfolio/_portfolio_cv.py
+++ b/autogluon_zeroshot/portfolio/_portfolio_cv.py
@@ -87,7 +87,7 @@ class PortfolioCV:
             portfolios += p.portfolios
         return PortfolioCV(portfolios=portfolios)
 
-    def get_overfitting_delta_overall(self) -> float:
+    def get_test_train_rank_diff(self) -> float:
         """
         Returns the amount of overfitting that has occurred.
         AKA: How overoptimistic the portfolio is on training compared to test

--- a/autogluon_zeroshot/portfolio/_portfolio_cv.py
+++ b/autogluon_zeroshot/portfolio/_portfolio_cv.py
@@ -11,7 +11,11 @@ class Portfolio:
                  test_datasets: List[str] = None,
                  train_datasets_fold: List[str] = None,
                  test_datasets_fold: List[str] = None,
-                 fold: int = None):
+                 fold: int = None,
+                 split: int = None,
+                 repeat: int = None,
+                 step: int = None,
+                 n_configs_avail: int = None):
         self.configs = configs
         self.train_score = train_score
         self.test_score = test_score
@@ -20,6 +24,14 @@ class Portfolio:
         self.train_datasets_fold = train_datasets_fold
         self.test_datasets_fold = test_datasets_fold
         self.fold = fold
+        self.split = split
+        self.repeat = repeat
+
+        # Optional, the step in which this portfolio was generated
+        # (relevant when portfolio is generated through iterative steps)
+        self.step = step
+
+        self.n_configs_avail = n_configs_avail  # Number of configs to choose from at fit time
 
 
 class PortfolioCV:

--- a/autogluon_zeroshot/portfolio/_portfolio_cv.py
+++ b/autogluon_zeroshot/portfolio/_portfolio_cv.py
@@ -40,6 +40,17 @@ class PortfolioCV:
         test_score = total_test_score / total_num_datasets
         return test_score
 
+    def get_train_score_overall(self):
+        total_num_datasets = 0
+        total_train_score = 0
+        for portfolio in self.portfolios:
+            train_score = portfolio.train_score
+            num_datasets = len(portfolio.train_datasets_fold)
+            total_num_datasets += num_datasets
+            total_train_score += train_score*num_datasets
+        train_score = total_train_score / total_num_datasets
+        return train_score
+
     def are_test_folds_unique(self) -> bool:
         """
         Return True if each test dataset is only present in one fold.
@@ -63,3 +74,11 @@ class PortfolioCV:
         for p in portfolio_cv_list:
             portfolios += p.portfolios
         return PortfolioCV(portfolios=portfolios)
+
+    def get_overfitting_delta_overall(self) -> float:
+        """
+        Returns the amount of overfitting that has occurred.
+        AKA: How overoptimistic the portfolio is on training compared to test
+        Lower = Better
+        """
+        return self.get_test_score_overall() - self.get_train_score_overall()

--- a/autogluon_zeroshot/simulation/config_generator.py
+++ b/autogluon_zeroshot/simulation/config_generator.py
@@ -1,10 +1,13 @@
 import copy
+from collections import defaultdict
+import math
+import random
 import time
-from typing import List
+from typing import Any, Dict, List
 
 import numpy as np
 import ray
-from sklearn.model_selection import KFold
+from sklearn.model_selection import RepeatedKFold
 
 from .configuration_list_scorer import ConfigurationListScorer
 from .simulation_context import ZeroshotSimulatorContext
@@ -27,14 +30,13 @@ class ZeroshotConfigGenerator:
     def select_zeroshot_configs(self,
                                 num_zeroshot: int,
                                 zeroshot_configs: List[str] = None,
-                                removal_stage=True,
+                                removal_stage=False,
                                 removal_threshold=0,
                                 config_scorer_test=None,
-                                ) -> List[str]:
-        if zeroshot_configs is None:
-            zeroshot_configs = []
-        else:
-            zeroshot_configs = copy.deepcopy(zeroshot_configs)
+                                return_all_metadata: bool = False,
+                                ) -> (List[Dict[str, Any]]):
+        zeroshot_configs = [] if zeroshot_configs is None else copy.deepcopy(zeroshot_configs)
+        metadata_list = []
 
         iteration = 0
         if self.backend == 'ray':
@@ -54,23 +56,40 @@ class ZeroshotConfigGenerator:
             if not valid_configs:
                 break
 
-
             time_start = time.time()
-            best_next_config, best_score = selector(valid_configs, zeroshot_configs, config_scorer)
+            best_next_config, train_score_best = selector(valid_configs, zeroshot_configs, config_scorer)
             time_end = time.time()
 
             zeroshot_configs.append(best_next_config)
-            msg = f'{iteration}\t: {round(best_score, 2)} | {round(time_end-time_start, 2)}s | {self.backend}'
+            fit_time = time_end - time_start
+            msg = f'{iteration}\t: Train: {round(train_score_best, 2)}'
             if config_scorer_test:
-                score_test = config_scorer_test.score(zeroshot_configs)
-                msg += f'\tTest: {round(score_test, 2)}'
-            msg += f'\t{best_next_config}'
-            print(msg)
+                test_score = config_scorer_test.score(zeroshot_configs)
+                msg += f'\t| Test: {round(test_score, 2)} \t| Overfit: {round(test_score-train_score_best, 2)}'
+            else:
+                test_score = None
+            msg += f' | {round(fit_time, 2)}s | {self.backend} | {best_next_config}'
+            # print('here, make metadata')
+            metadata_out = dict(
+                configs=copy.deepcopy(zeroshot_configs),
+                new_config=best_next_config,
+                train_score=train_score_best,
+                test_score=test_score,
+                num_configs=len(zeroshot_configs),
+                fit_time=fit_time,
+                backend=self.backend,
+            )
+            is_last = len(zeroshot_configs) >= num_zeroshot
+            if return_all_metadata or is_last:
+                metadata_list.append(metadata_out)
 
+            print(msg)
         if removal_stage:
+            raise NotImplementedError('Currently removal_stage=True does not work correctly')
             zeroshot_configs = self.prune_zeroshot_configs(zeroshot_configs, removal_threshold=removal_threshold)
         print(f"selected {zeroshot_configs}")
-        return zeroshot_configs
+        # TODO: metadata_list not updated by prune_zeroshot_configs
+        return metadata_list
 
     @staticmethod
     def _select_sequential(configs: list, prior_configs: list, config_scorer):
@@ -134,19 +153,23 @@ class ZeroshotConfigGeneratorCV:
                  config_scorer: ConfigurationListScorer,
                  config_generator_kwargs=None,
                  configs: List[str] = None,
+                 n_repeats: int = 1,
                  backend='ray'):
         """
         Runs zero-shot selection on `n_splits` ("train", "test") folds of datasets.
         For each split, zero-shot configurations are selected using the datasets belonging on the "train" split and the
         performance of the zero-shot configuration is evaluated using the datasets in the "test" split.
-        :param n_splits: number of split to consider
+        :param n_splits: number of splits for RepeatedKFold
         :param zeroshot_simulator_context:
         :param config_scorer:
         :param configs:
+        :param n_repeats: number of repeats for RepeatedKFold
         :param backend:
         """
         assert n_splits >= 2
+        assert n_repeats >= 1
         self.n_splits = n_splits
+        self.n_repeats = n_repeats
         if config_generator_kwargs is None:
             config_generator_kwargs = {}
         self.config_generator_kwargs = config_generator_kwargs
@@ -171,37 +194,117 @@ class ZeroshotConfigGeneratorCV:
             configs = zeroshot_simulator_context.get_configs()
         self.configs = configs
 
-        self.kf = KFold(n_splits=self.n_splits, random_state=0, shuffle=True)
+        self.kf = RepeatedKFold(n_splits=self.n_splits, random_state=0, n_repeats=self.n_repeats)
 
-    def run(self) -> PortfolioCV:
-        results_list = []
+    def _get_dataset_parent_to_fold(self, dataset: str, num_folds=None) -> List[str]:
+        if num_folds is None:
+            return self.dataset_parent_to_fold_map[dataset]
+        else:
+            return self.dataset_parent_to_fold_map[dataset][:num_folds]
+
+    def run_and_return_all_steps(self,
+                                 sample_train_folds: int = None,
+                                 sample_train_ratio: float = None,
+                                 score_all: bool = True,
+                                 score_final: bool = True,
+                                 return_all_metadata: bool = True) -> List[PortfolioCV]:
+        """
+        Run cross-validated zeroshot simulation.
+
+        :param sample_train_folds:
+            Number of folds to filter training data to for each fold. Used for debugging.
+            Lower values should result in worse test scores and higher overfit scores
+            If set to a value larger than the folds available in the datasets, it will have no effect.
+        :param sample_train_ratio:
+            Ratio of datasets to filter training data to for each fold. Used for debugging.
+            Lower values should result in worse test scores and higher overfit scores
+        :param score_all: If True, calculates test score at each step of the zeroshot simulation process.
+        :param score_final: If True, calculates test score for the final step of the zeroshot simulation process.
+        :param return_all_metadata:
+            If True, returns N elements in a list, with the index referring to the order of selection.
+                Note: If folds differ in number of simulation steps, this will raise an exception.
+                For example, config pruning as a post-processing step to greedy selection
+                of N elements could have differing step counts.
+            If False, returns a list with only 1 element corresponding to the final zeroshot config.
+        """
+        results_dict_by_len = defaultdict(list)
         for i, (train_index, test_index) in enumerate(self.kf.split(self.unique_datasets)):
-            print(f'Fitting Fold {i+1}...')
             X_train, X_test = list(self.unique_datasets[train_index]), list(self.unique_datasets[test_index])
+            len_X_train_og = len(X_train)
+            len_X_test_og = len(X_test)
+            if sample_train_ratio is not None and sample_train_ratio < 1:
+                random.seed(0)
+                num_samples = math.ceil(len(X_train) * sample_train_ratio)
+                X_train = random.sample(X_train, num_samples)
             X_train_fold = []
             X_test_fold = []
             for d in X_train:
-                X_train_fold += self.dataset_parent_to_fold_map[d]
+                X_train_fold += self._get_dataset_parent_to_fold(dataset=d, num_folds=sample_train_folds)
             for d in X_test:
                 X_test_fold += self.dataset_parent_to_fold_map[d]
-            zeroshot_configs_fold, score_fold = self.run_fold(X_train_fold, X_test_fold)
-            results_fold = Portfolio(
-                configs=zeroshot_configs_fold,
-                train_score=None,
-                test_score=score_fold,
-                train_datasets=X_train,
-                test_datasets=X_test,
-                train_datasets_fold=X_train_fold,
-                test_datasets_fold=X_test_fold,
-                fold=i+1,
-            )
-            results_list.append(results_fold)
-        results = PortfolioCV(portfolios=results_list)
-        return results
+            len_X_train_fold = len(X_train_fold)
+            len_X_train = len(X_train)
+            print(f'Fitting Fold {i + 1}/{self.n_splits*self.n_repeats}... '
+                  f'(n_splits={self.n_splits}, n_repeats={self.n_repeats})\n'
+                  f'\tsample_train_folds={sample_train_folds} | sample_train_ratio={sample_train_ratio}\n'
+                  f'\ttrain_datasets: {len_X_train}/{len_X_train_og} | train_tasks: {len_X_train_fold}\n'
+                  f'\ttest_datasets : {len(X_test)}/{len_X_test_og} | test_tasks : {len(X_test_fold)}'
+                  )
+            metadata_fold = self.run_fold(X_train_fold,
+                                          X_test_fold,
+                                          score_all=score_all,
+                                          score_final=score_final,
+                                          return_all_metadata=return_all_metadata)
+            for j, m in enumerate(metadata_fold):
+                # FIXME: It is possible not all folds will have results match up correctly
+                #  if we introduce config pruning.
+                #  This logic should probably only be present in scenarios where we are debugging
+                #  Otherwise we should only take the final result of each fold.
+                results_fold_i = Portfolio(
+                    configs=m['configs'],
+                    train_score=m['train_score'],
+                    test_score=m['test_score'],
+                    train_datasets=X_train,
+                    test_datasets=X_test,
+                    train_datasets_fold=X_train_fold,
+                    test_datasets_fold=X_test_fold,
+                    fold=i + 1,
+                )
+                results_dict_by_len[j].append(results_fold_i)
+        for val in results_dict_by_len.values():
+            assert (self.n_splits * self.n_repeats) == len(val)  # Ensure no bugs such as only getting a subset of fold results
+        portfolio_cv_list = [PortfolioCV(portfolios=v) for k, v in results_dict_by_len.items()]
+        return portfolio_cv_list
 
-    def run_fold(self, X_train, X_test):
-        config_scorer_train = self.config_scorer.subset(datasets=X_train)
-        config_scorer_test = self.config_scorer.subset(datasets=X_test)
+    def run(self,
+            sample_train_folds=None,
+            sample_train_ratio=None,
+            score_all=False,
+            score_final=True) -> PortfolioCV:
+        """
+        Identical to `run_and_return_all_steps`, but the output is simply the final PortfolioCV.
+
+        score_all is also set to False by default to speed up the simulation.
+        """
+        results_cv_list = self.run_and_return_all_steps(sample_train_folds=sample_train_folds,
+                                                        sample_train_ratio=sample_train_ratio,
+                                                        score_all=score_all,
+                                                        score_final=score_final,
+                                                        return_all_metadata=False)
+
+        assert len(results_cv_list) == 1
+        results_cv = results_cv_list[0]
+
+        return results_cv
+
+    def run_fold(self,
+                 train_tasks: List[str],
+                 test_tasks: List[str],
+                 score_all=False,
+                 score_final=True,
+                 return_all_metadata=False) -> List[Dict[str, Any]]:
+        config_scorer_train = self.config_scorer.subset(datasets=train_tasks)
+        config_scorer_test = self.config_scorer.subset(datasets=test_tasks)
 
         zs_config_generator = ZeroshotConfigGenerator(config_scorer=config_scorer_train,
                                                       configs=self.configs,
@@ -210,16 +313,19 @@ class ZeroshotConfigGeneratorCV:
         num_zeroshot = self.config_generator_kwargs.get('num_zeroshot', 10)
         removal_stage = self.config_generator_kwargs.get('removal_stage', False)
 
-        zeroshot_configs = zs_config_generator.select_zeroshot_configs(num_zeroshot=num_zeroshot,
-                                                                       removal_stage=removal_stage,
-                                                                       # config_scorer_test=config_scorer_test
-                                                                       )
+        metadata_list = zs_config_generator.select_zeroshot_configs(
+            num_zeroshot=num_zeroshot,
+            removal_stage=removal_stage,
+            config_scorer_test=config_scorer_test if score_all else None,
+            return_all_metadata=return_all_metadata,
+        )
         # deleting
         # FIXME: SPEEDUP WITH RAY
         # zeroshot_configs = zs_config_generator.prune_zeroshot_configs(zeroshot_configs, removal_threshold=0)
 
-        # Consider making test scoring optional here
-        score = config_scorer_test.score(zeroshot_configs)
-        print(f'score: {score}')
+        if score_final and metadata_list[-1]['test_score'] is None:
+            score = config_scorer_test.score(metadata_list[-1]['configs'])
+            print(f'test_score: {score}')
+            metadata_list[-1]['test_score'] = score
 
-        return zeroshot_configs, score
+        return metadata_list

--- a/autogluon_zeroshot/simulation/config_generator.py
+++ b/autogluon_zeroshot/simulation/config_generator.py
@@ -57,15 +57,15 @@ class ZeroshotConfigGenerator:
             iteration += 1
 
             time_start = time.time()
-            best_next_config, train_score_best = selector(valid_configs, zeroshot_configs, config_scorer)
+            best_next_config, best_train_score = selector(valid_configs, zeroshot_configs, config_scorer)
             time_end = time.time()
 
             zeroshot_configs.append(best_next_config)
             fit_time = time_end - time_start
-            msg = f'{iteration}\t: Train: {round(train_score_best, 2)}'
+            msg = f'{iteration}\t: Train: {round(best_train_score, 2)}'
             if config_scorer_test:
                 test_score = config_scorer_test.score(zeroshot_configs)
-                msg += f'\t| Test: {round(test_score, 2)} \t| Overfit: {round(test_score-train_score_best, 2)}'
+                msg += f'\t| Test: {round(test_score, 2)} \t| Overfit: {round(test_score-best_train_score, 2)}'
             else:
                 test_score = None
             msg += f' | {round(fit_time, 2)}s | {self.backend} | {best_next_config}'
@@ -74,7 +74,7 @@ class ZeroshotConfigGenerator:
                 configs=copy.deepcopy(zeroshot_configs),
                 new_config=best_next_config,
                 step=iteration,
-                train_score=train_score_best,
+                train_score=best_train_score,
                 test_score=test_score,
                 num_configs=len(zeroshot_configs),
                 fit_time=fit_time,

--- a/autogluon_zeroshot/simulation/config_generator.py
+++ b/autogluon_zeroshot/simulation/config_generator.py
@@ -48,13 +48,13 @@ class ZeroshotConfigGenerator:
             config_scorer = self.config_scorer
             selector = self._select_sequential
         while len(zeroshot_configs) < num_zeroshot:
-            iteration += 1
             # greedily search the config that would yield the lowest average rank if we were to evaluate it in combination
             # with previously chosen configs.
 
             valid_configs = [c for c in self.all_configs if c not in zeroshot_configs]
             if not valid_configs:
                 break
+            iteration += 1
 
             time_start = time.time()
             best_next_config, train_score_best = selector(valid_configs, zeroshot_configs, config_scorer)
@@ -73,6 +73,7 @@ class ZeroshotConfigGenerator:
             metadata_out = dict(
                 configs=copy.deepcopy(zeroshot_configs),
                 new_config=best_next_config,
+                step=iteration,
                 train_score=train_score_best,
                 test_score=test_score,
                 num_configs=len(zeroshot_configs),
@@ -85,11 +86,50 @@ class ZeroshotConfigGenerator:
 
             print(msg)
         if removal_stage:
-            raise NotImplementedError('Currently removal_stage=True does not work correctly')
             zeroshot_configs = self.prune_zeroshot_configs(zeroshot_configs, removal_threshold=removal_threshold)
+
+            # FIXME: Get this from prune instead
+            metadata_out = self._get_metadata_from_configs(
+                configs=zeroshot_configs,
+                step=iteration+1,
+                train_score=None,
+                test_score=None,
+                config_scorer=self.config_scorer,
+                config_scorer_test=config_scorer_test,
+            )
+
+            if return_all_metadata:
+                metadata_list.append(metadata_out)
+            else:
+                metadata_list = [metadata_out]
+
         print(f"selected {zeroshot_configs}")
         # TODO: metadata_list not updated by prune_zeroshot_configs
         return metadata_list
+
+    def _get_metadata_from_configs(self,
+                                   configs,
+                                   new_config=None,
+                                   step=None,
+                                   train_score=None,
+                                   test_score=None,
+                                   fit_time=None,
+                                   config_scorer=None,
+                                   config_scorer_test=None) -> Dict[str, Any]:
+        if train_score is None and config_scorer is not None:
+            train_score = config_scorer.score(configs)
+        if test_score is None and config_scorer_test is not None:
+            test_score = config_scorer_test.score(configs)
+        return dict(
+            configs=copy.deepcopy(configs),
+            new_config=new_config,
+            step=step,
+            train_score=train_score,
+            test_score=test_score,
+            num_configs=len(configs),
+            fit_time=fit_time,
+            backend=self.backend,
+        )
 
     @staticmethod
     def _select_sequential(configs: list, prior_configs: list, config_scorer):
@@ -196,15 +236,45 @@ class ZeroshotConfigGeneratorCV:
 
         self.kf = RepeatedKFold(n_splits=self.n_splits, random_state=0, n_repeats=self.n_repeats)
 
-    def _get_dataset_parent_to_fold(self, dataset: str, num_folds=None) -> List[str]:
+    def get_n_tasks(self) -> int:
+        return len(self.unique_datasets_fold)
+
+    def get_n_datasets(self) -> int:
+        return len(self.unique_datasets)
+
+    def get_n_configs(self) -> int:
+        return len(self.configs)
+
+    def _get_tasks_from_datasets(self, datasets: List[str], num_folds=None) -> List[str]:
+        tasks = []
+        for d in datasets:
+            tasks += self._get_tasks_from_dataset(dataset=d, num_folds=num_folds)
+        return tasks
+
+    def _get_tasks_from_dataset(self, dataset: str, num_folds=None) -> List[str]:
         if num_folds is None:
             return self.dataset_parent_to_fold_map[dataset]
         else:
             return self.dataset_parent_to_fold_map[dataset][:num_folds]
 
+    def _get_split(self, fold: int) -> int:
+        """
+        Note: fold 0 is the first fold, not fold 1.
+        split 0 is the first split.
+        """
+        return fold % self.n_splits
+
+    def _get_repeat(self, fold: int) -> int:
+        """
+        repeat 0 is the first repeat
+        """
+        return int(fold / self.n_splits)
+
     def run_and_return_all_steps(self,
                                  sample_train_folds: int = None,
                                  sample_train_ratio: float = None,
+                                 sample_configs_ratio: float = None,
+                                 # TODO: Sample configs
                                  score_all: bool = True,
                                  score_final: bool = True,
                                  return_all_metadata: bool = True) -> List[PortfolioCV]:
@@ -218,6 +288,9 @@ class ZeroshotConfigGeneratorCV:
         :param sample_train_ratio:
             Ratio of datasets to filter training data to for each fold. Used for debugging.
             Lower values should result in worse test scores and higher overfit scores
+        :param sample_configs_ratio:
+            Ratio of configs to filter to for each fold. Used for debugging.
+            Lower values should result in worse test scores and lower overfit scores
         :param score_all: If True, calculates test score at each step of the zeroshot simulation process.
         :param score_final: If True, calculates test score for the final step of the zeroshot simulation process.
         :param return_all_metadata:
@@ -228,30 +301,46 @@ class ZeroshotConfigGeneratorCV:
             If False, returns a list with only 1 element corresponding to the final zeroshot config.
         """
         results_dict_by_len = defaultdict(list)
+        n_configs_total = self.get_n_configs()
+        is_first_fold = True
+        configs = self.configs
+        print(f'Fitting CV\n'
+              f'\tscorer={self.config_scorer.__class__.__name__}\n'
+              f'\tn_splits={self.n_splits}, n_repeats={self.n_repeats}, n_configs={n_configs_total}\n'
+              f'\tn_datasets={self.get_n_datasets()}, n_tasks={self.get_n_tasks()}\n'
+              f'\tsample_train_folds={sample_train_folds} '
+              f'| sample_train_ratio={sample_train_ratio} '
+              f'| sample_configs_ratio={sample_configs_ratio}'
+              )
         for i, (train_index, test_index) in enumerate(self.kf.split(self.unique_datasets)):
+            split = self._get_split(i)
+            repeat = self._get_repeat(i)
             X_train, X_test = list(self.unique_datasets[train_index]), list(self.unique_datasets[test_index])
             len_X_train_og = len(X_train)
             len_X_test_og = len(X_test)
+            if split == 0 or is_first_fold:
+                if sample_configs_ratio is not None and sample_configs_ratio < 1:
+                    random.seed(repeat)
+                    num_samples = math.ceil(n_configs_total * sample_configs_ratio)
+                    configs = random.sample(self.configs, num_samples)
             if sample_train_ratio is not None and sample_train_ratio < 1:
                 random.seed(0)
                 num_samples = math.ceil(len(X_train) * sample_train_ratio)
                 X_train = random.sample(X_train, num_samples)
-            X_train_fold = []
-            X_test_fold = []
-            for d in X_train:
-                X_train_fold += self._get_dataset_parent_to_fold(dataset=d, num_folds=sample_train_folds)
-            for d in X_test:
-                X_test_fold += self.dataset_parent_to_fold_map[d]
-            len_X_train_fold = len(X_train_fold)
-            len_X_train = len(X_train)
-            print(f'Fitting Fold {i + 1}/{self.n_splits*self.n_repeats}... '
-                  f'(n_splits={self.n_splits}, n_repeats={self.n_repeats})\n'
-                  f'\tsample_train_folds={sample_train_folds} | sample_train_ratio={sample_train_ratio}\n'
-                  f'\ttrain_datasets: {len_X_train}/{len_X_train_og} | train_tasks: {len_X_train_fold}\n'
-                  f'\ttest_datasets : {len(X_test)}/{len_X_test_og} | test_tasks : {len(X_test_fold)}'
+            random.seed(0)
+            n_configs_avail = len(configs)
+            train_tasks = self._get_tasks_from_datasets(datasets=X_train, num_folds=sample_train_folds)
+            test_tasks = self._get_tasks_from_datasets(datasets=X_test)
+            len_train_tasks = len(train_tasks)
+            len_train_datasets = len(X_train)
+            print(f'Fitting Fold {i + 1}/{self.n_splits*self.n_repeats} (R{repeat+1}S{split+1})...\n'
+                  f'\ttrain_datasets: {len_train_datasets}/{len_X_train_og} | train_tasks: {len_train_tasks}\n'
+                  f'\ttest_datasets : {len(X_test)}/{len_X_test_og} | test_tasks : {len(test_tasks)}\n'
+                  f'\tn_configs={n_configs_avail}/{n_configs_total}'
                   )
-            metadata_fold = self.run_fold(X_train_fold,
-                                          X_test_fold,
+            metadata_fold = self.run_fold(train_tasks,
+                                          test_tasks,
+                                          configs=configs,
                                           score_all=score_all,
                                           score_final=score_final,
                                           return_all_metadata=return_all_metadata)
@@ -266,11 +355,16 @@ class ZeroshotConfigGeneratorCV:
                     test_score=m['test_score'],
                     train_datasets=X_train,
                     test_datasets=X_test,
-                    train_datasets_fold=X_train_fold,
-                    test_datasets_fold=X_test_fold,
+                    train_datasets_fold=train_tasks,
+                    test_datasets_fold=test_tasks,
                     fold=i + 1,
+                    split=split+1,
+                    repeat=repeat+1,
+                    step=m['step'],
+                    n_configs_avail=n_configs_avail,
                 )
                 results_dict_by_len[j].append(results_fold_i)
+            is_first_fold = False
         for val in results_dict_by_len.values():
             assert (self.n_splits * self.n_repeats) == len(val)  # Ensure no bugs such as only getting a subset of fold results
         portfolio_cv_list = [PortfolioCV(portfolios=v) for k, v in results_dict_by_len.items()]
@@ -300,14 +394,17 @@ class ZeroshotConfigGeneratorCV:
     def run_fold(self,
                  train_tasks: List[str],
                  test_tasks: List[str],
+                 configs: List[str] = None,
                  score_all=False,
                  score_final=True,
                  return_all_metadata=False) -> List[Dict[str, Any]]:
+        if configs is None:
+            configs = self.configs
         config_scorer_train = self.config_scorer.subset(datasets=train_tasks)
         config_scorer_test = self.config_scorer.subset(datasets=test_tasks)
 
         zs_config_generator = ZeroshotConfigGenerator(config_scorer=config_scorer_train,
-                                                      configs=self.configs,
+                                                      configs=configs,
                                                       backend=self.backend)
 
         num_zeroshot = self.config_generator_kwargs.get('num_zeroshot', 10)

--- a/autogluon_zeroshot/simulation/sim_runner.py
+++ b/autogluon_zeroshot/simulation/sim_runner.py
@@ -33,7 +33,7 @@ def run_zs_simulation(zsc: ZeroshotSimulatorContext, config_scorer, n_splits=10,
     print(f'Overall (CV) | '
           f'Test Score: {portfolio_cv.get_test_score_overall()} | '
           f'Train Score: {portfolio_cv.get_train_score_overall()} | '
-          f'Overfit Score: {portfolio_cv.get_overfitting_delta_overall()}')
+          f'Overfit Score: {portfolio_cv.get_test_train_rank_diff()}')
 
     return portfolio_cv
 
@@ -48,7 +48,7 @@ def plot_results_multi(portfolio_cv_lists: List[List[PortfolioCV]],
     fig = plt.figure(dpi=300)
     ax = fig.subplots()
     for portfolio_cv_list in portfolio_cv_lists:
-        df, num_train_tasks, num_test_tasks, n_configs_avail = get_overfit_delta_df(portfolio_cv_list=portfolio_cv_list)
+        df, num_train_tasks, num_test_tasks, n_configs_avail = get_test_train_rank_diff_df(portfolio_cv_list=portfolio_cv_list)
         ax.scatter(df[x_axis_col], df['overfit_delta'], alpha=0.5, label=f'tr_tasks={num_train_tasks}, n_conf={n_configs_avail}')
     ax.set_xlabel(x_axis_col)
     ax.set_ylabel('Overfit delta rank (lower is better)')
@@ -77,7 +77,7 @@ def plot_results_multi(portfolio_cv_lists: List[List[PortfolioCV]],
     # ax.scatter(df['num_configs'], df['test_score'], alpha=0.5, label='test')
     # ax.scatter(df['num_configs'], df['train_score'], alpha=0.5, label='train')
     for ax, portfolio_cv_list in zip(axes.flat[:num_lists], portfolio_cv_lists):
-        df, num_train_tasks, num_test_tasks, n_configs_avail = get_overfit_delta_df(portfolio_cv_list=portfolio_cv_list)
+        df, num_train_tasks, num_test_tasks, n_configs_avail = get_test_train_rank_diff_df(portfolio_cv_list=portfolio_cv_list)
         ax.scatter(df[x_axis_col], df['test_score'], alpha=0.5, label=f'test')
         ax.scatter(df[x_axis_col], df['train_score'], alpha=0.5, label=f'train')
 
@@ -100,7 +100,7 @@ def plot_results_multi(portfolio_cv_lists: List[List[PortfolioCV]],
     plt.show()
 
 
-def get_overfit_delta_df(portfolio_cv_list: List[PortfolioCV]):
+def get_test_train_rank_diff_df(portfolio_cv_list: List[PortfolioCV]):
     from collections import defaultdict
     df_dict = defaultdict(list)
 

--- a/autogluon_zeroshot/simulation/sim_runner.py
+++ b/autogluon_zeroshot/simulation/sim_runner.py
@@ -1,3 +1,9 @@
+from datetime import datetime
+import math
+import os
+from typing import Dict, List
+
+import matplotlib.pyplot as plt
 
 from .config_generator import ZeroshotConfigGeneratorCV
 from .simulation_context import ZeroshotSimulatorContext
@@ -13,7 +19,6 @@ def run_zs_simulation(zsc: ZeroshotSimulatorContext, config_scorer, n_splits=10,
         configs=configs,
         backend=backend,
     )
-
     portfolio_cv = zs_config_generator_cv.run()
 
     portfolios = portfolio_cv.portfolios
@@ -21,6 +26,176 @@ def run_zs_simulation(zsc: ZeroshotSimulatorContext, config_scorer, n_splits=10,
         print(f'Fold {portfolios[i].fold} Selected Configs: {portfolios[i].configs}')
 
     for i in range(len(portfolios)):
-        print(f'Fold {portfolios[i].fold} Test Score: {portfolios[i].test_score}')
+        print(f'Fold {portfolios[i].fold} | '
+              f'Test Score: {portfolios[i].test_score} | '
+              f'Train Score: {portfolios[i].train_score}')
+
+    print(f'Overall (CV) | '
+          f'Test Score: {portfolio_cv.get_test_score_overall()} | '
+          f'Train Score: {portfolio_cv.get_train_score_overall()} | '
+          f'Overfit Score: {portfolio_cv.get_overfitting_delta_overall()}')
 
     return portfolio_cv
+
+
+def plot_results_multi(portfolio_cv_lists: List[List[PortfolioCV]],
+                       title: str = None,
+                       footnote: str = None,
+                       save_prefix: str = None):
+    if title is None:
+        title = f"Overfitting Delta"
+    fig = plt.figure(dpi=300)
+    ax = fig.subplots()
+    for portfolio_cv_list in portfolio_cv_lists:
+        df, num_train_tasks, num_test_tasks = get_overfit_delta_df(portfolio_cv_list=portfolio_cv_list)
+        ax.scatter(df['num_configs'], df['overfit_delta'], alpha=0.5, label=f'train_tasks={num_train_tasks}')
+    ax.set_xlabel('num_configs')
+    ax.set_ylabel('Overfit delta rank (lower is better)')
+    ax.set_title(title)
+    if footnote is not None:
+        plt.figtext(0.99, 0.01, footnote, horizontalalignment='right')
+    ax.grid()
+    ax.legend()
+    if save_prefix is not None:
+        save_path = f'{save_prefix}overfit_delta_comparison.png'
+        mkdir_path(save_path)
+        plt.savefig(save_path)
+    plt.show()
+
+    # TODO: Split into separate function, avoid 2 plots in 1 function
+    num_lists = len(portfolio_cv_lists)
+    num_lists_sqrt = math.ceil(math.sqrt(num_lists))
+    num_x = num_lists_sqrt
+    num_y = num_lists_sqrt
+    while num_x * num_y >= num_lists:
+        num_y -= 1
+    num_y += 1
+    fig, axes = plt.subplots(num_y, num_x, sharex=True, sharey=True)
+    fig.set_size_inches(8, 8)
+    fig.set_dpi(300)
+    # ax.scatter(df['num_configs'], df['test_score'], alpha=0.5, label='test')
+    # ax.scatter(df['num_configs'], df['train_score'], alpha=0.5, label='train')
+    for ax, portfolio_cv_list in zip(axes.flat[:num_lists], portfolio_cv_lists):
+        df, num_train_tasks, num_test_tasks = get_overfit_delta_df(portfolio_cv_list=portfolio_cv_list)
+        ax.scatter(df['num_configs'], df['test_score'], alpha=0.5, label=f'test')
+        ax.scatter(df['num_configs'], df['train_score'], alpha=0.5, label=f'train')
+
+        # ax.set_xlabel('num_configs')  # Add an x-label to the axes.
+        # ax.set_ylabel('rank (lower is better)')  # Add a y-label to the axes.
+        ax.set_title(f'train_tasks={num_train_tasks}')  # Add a title to the axes.
+        ax.grid()
+    axes.flat[0].legend()
+    # axes[0].set_xlabel('num_configs')  # Add an x-label to the axes.
+    # axes.flat[0].set_ylabel('rank (lower is better)')  # Add a y-label to the axes.
+    if footnote is not None:
+        plt.figtext(0.99, 0.01, footnote, horizontalalignment='right')
+    fig.suptitle(title)
+    fig.supxlabel('num_configs')
+    fig.supylabel('rank (lower is better)')
+    if save_prefix is not None:
+        save_path = f'{save_prefix}train_test_comparison.png'
+        mkdir_path(save_path)
+        plt.savefig(save_path)
+    plt.show()
+
+
+def get_overfit_delta_df(portfolio_cv_list: List[PortfolioCV]):
+    from collections import defaultdict
+    df_dict = defaultdict(list)
+
+    num_train_tasks = None
+    num_test_tasks = None
+
+    for portfolio_cv in portfolio_cv_list:
+        portfolios = portfolio_cv.portfolios
+        if num_train_tasks is None:
+            num_train_tasks = len(portfolios[0].train_datasets_fold)
+        if num_test_tasks is None:
+            num_test_tasks = len(portfolios[0].test_datasets_fold)
+        num_configs = len(portfolios[0].configs)
+        # print(k)
+        # for i in range(len(portfolios)):
+        #     print(f'Fold {portfolios[i].fold} Selected Configs: {portfolios[i].configs}')
+        #
+        # for i in range(len(portfolios)):
+        #     print(f'Fold {portfolios[i].fold} Test Score: {portfolios[i].test_score}')
+
+        df_dict['num_configs'].append(num_configs)
+        df_dict['test_score'].append(portfolio_cv.get_test_score_overall())
+        df_dict['train_score'].append(portfolio_cv.get_train_score_overall())
+
+    import pandas as pd
+    df = pd.DataFrame(df_dict)
+    df['overfit_delta'] = df['test_score'] - df['train_score']
+    return df, num_train_tasks, num_test_tasks
+
+
+def run_zs_simulation_debug(zsc: ZeroshotSimulatorContext,
+                            config_scorer,
+                            n_splits=10,
+                            n_repeats=1,
+                            config_generator_kwargs=None,
+                            configs=None,
+                            backend='ray',
+                            num_halving=5) -> List[List[PortfolioCV]]:
+    """
+    num_halving:
+        The number of times the training data is halved to measure increase in overfitting / decrease in test score
+
+    """
+    zs_config_generator_cv = ZeroshotConfigGeneratorCV(
+        n_splits=n_splits,
+        n_repeats=n_repeats,
+        zeroshot_simulator_context=zsc,
+        config_scorer=config_scorer,
+        config_generator_kwargs=config_generator_kwargs,
+        configs=configs,
+        backend=backend,
+    )
+    num_folds = len(zsc.folds)
+
+    settings = [
+        dict(
+            sample_train_folds=None,
+            sample_train_ratio=None,
+        )
+    ]
+
+    if num_halving is not None and num_halving >= 1:
+        cur_train_folds = num_folds
+        cur_train_ratio = 1
+        for i in range(num_halving):
+            if cur_train_folds == 1:
+                cur_train_ratio /= 2
+            else:
+                cur_train_folds = max(int(cur_train_folds / 2), 1)
+            settings.append(
+                dict(
+                    sample_train_folds=cur_train_folds,
+                    sample_train_ratio=cur_train_ratio,
+                )
+            )
+
+    portfolio_cv_lists = []
+    for setting in settings:
+        portfolio_cv_list = zs_config_generator_cv.run_and_return_all_steps(**setting)
+        portfolio_cv_lists.append(portfolio_cv_list)
+
+    utcnow = datetime.utcnow()
+    timestamp = utcnow.strftime("%Y%m%d_%H%M%S")
+    plot_results_multi(portfolio_cv_lists,
+                       title=f'Overfit Delta: n_configs={len(zsc.get_configs())}, n_tasks={len(zsc.get_dataset_folds())}, '
+                             f'n_splits={n_splits}, n_repeats={n_repeats}',
+                       footnote=f'scorer={config_scorer.__class__.__name__}',
+                       save_prefix=f'plots/{timestamp}/')
+
+    # plot_results(portfolio_cv_dict)
+
+    return portfolio_cv_lists
+
+
+def mkdir_path(path):
+    path_parent = os.path.dirname(path)
+    if path_parent == '':
+        path_parent = '.'
+    os.makedirs(path_parent, exist_ok=True)

--- a/scripts/method_comparison/run_method_comparison.py
+++ b/scripts/method_comparison/run_method_comparison.py
@@ -88,7 +88,8 @@ def compute_zeroshot(
         configs=models,
         backend="ray",
     )
-    zeroshot_configs = zs_config_generator.select_zeroshot_configs(num_models, removal_stage=False)
+    metadata_list = zs_config_generator.select_zeroshot_configs(num_models, removal_stage=False)
+    zeroshot_configs = metadata_list[-1]['configs']
     return zeroshot_configs
 
 

--- a/scripts/simulate/bagged/run_inspect_overfit.py
+++ b/scripts/simulate/bagged/run_inspect_overfit.py
@@ -1,0 +1,33 @@
+from autogluon_zeroshot.simulation.single_best_config_scorer import SingleBestConfigScorer
+from autogluon_zeroshot.contexts.context_2022_12_11_bag import load_context_2022_12_11_bag
+from autogluon_zeroshot.simulation.sim_runner import run_zs_simulation_debug
+
+
+if __name__ == '__main__':
+    zsc, configs_full, zeroshot_pred_proba, zeroshot_gt = load_context_2022_12_11_bag(
+        subset='small_30'
+    )
+    zsc.print_info()
+
+    # NOTE: For speed of simulation, it is recommended backend='ray'
+    backend = 'ray'
+
+    # configs = get_configs_small()
+    configs = None
+
+    datasets = zsc.get_dataset_folds()
+
+    config_scorer = SingleBestConfigScorer.from_zsc(
+        zeroshot_simulator_context=zsc,
+        datasets=datasets,
+    )
+
+    run_zs_simulation_debug(
+        zsc=zsc,
+        config_scorer=config_scorer,
+        n_splits=5,
+        n_repeats=10,
+        configs=configs,
+        config_generator_kwargs={'num_zeroshot': 20},
+        backend=backend,
+    )

--- a/scripts/simulate/bagged_208/run_inspect_overfit.py
+++ b/scripts/simulate/bagged_208/run_inspect_overfit.py
@@ -1,0 +1,31 @@
+from autogluon_zeroshot.simulation.single_best_config_scorer import SingleBestConfigScorer
+from autogluon_zeroshot.contexts.context_2023_02_27_bag_208 import load_context_2023_02_27_bag_208
+from autogluon_zeroshot.simulation.sim_runner import run_zs_simulation_debug
+
+
+if __name__ == '__main__':
+    zsc, configs_full, zeroshot_pred_proba, zeroshot_gt = load_context_2023_02_27_bag_208()
+    zsc.print_info()
+
+    # NOTE: For speed of simulation, it is recommended backend='ray'
+    backend = 'ray'
+
+    # configs = get_configs_small()
+    configs = None
+
+    datasets = zsc.get_dataset_folds()
+
+    config_scorer = SingleBestConfigScorer.from_zsc(
+        zeroshot_simulator_context=zsc,
+        datasets=datasets,
+    )
+
+    run_zs_simulation_debug(
+        zsc=zsc,
+        config_scorer=config_scorer,
+        n_splits=5,
+        n_repeats=10,
+        configs=configs,
+        config_generator_kwargs={'num_zeroshot': 20},
+        backend=backend,
+    )


### PR DESCRIPTION
Add debugging, repeatedkfold, plots

- This PR includes a lot of functionality to improve our ability to understand what is going on in the simulation process and detect if we are overfitting. In particular this PR allows us to get the test and train scores at each step of the greedy forward selection process, and plot the results.
- Run either of the `run_inspect_overfit.py` files to see the output of the debugging process, including plots.
  - Running the script will take ~10 minutes on a `m6i.16xlarge`.

# Bagged Plots 

![overfit_delta_comparison (1)](https://user-images.githubusercontent.com/16392542/224596554-97f4be4e-f900-4c33-af9e-da2107f9938d.png)
![train_test_comparison (1)](https://user-images.githubusercontent.com/16392542/224596561-e158c802-b454-407f-8c57-2e6dd357134e.png)


# Bagged 208 Plots (this is more overfit despite having more datasets because it only has 1 fold instead of 10)

![train_test_comparison](https://user-images.githubusercontent.com/16392542/224596574-47221a09-65f1-4cf5-9e8b-4846d6d79dfd.png)
![overfit_delta_comparison](https://user-images.githubusercontent.com/16392542/224596579-73519014-d324-404a-a630-a39ebc7d8d9c.png)

# Next Steps:
- [ ] Add automatic saving of plots to s3
- [ ] Save debug PortfolioCV output to disk/s3, to simplify reproducing plots
- [ ] Add inspection for impact of n_configs on overfitting
- [ ] Add error bars / stddev of plots when using repeatedkfold (can calculate based on score difference between each kfold repeat)
- [ ] Do a run of inspect / debug using EnsembleScorer (will take awhile to run the compute, probably a full day)
- [ ] Fix `prune_zeroshot_configs` (currently not working due to change in output format of sim runs)