### PR TITLE
add partial_rank support

### DIFF
--- a/autogluon_zeroshot/utils/rank_utils.py
+++ b/autogluon_zeroshot/utils/rank_utils.py
@@ -4,14 +4,30 @@ import numpy as np
 import pandas as pd
 
 
-def get_rank(error: float, error_lst: List[float], higher_is_better: bool = False, ties_win: bool = False, pct: bool = False) -> float:
+def get_rank(error: float,
+             error_lst: List[float],
+             ties_win: bool = False,
+             pct: bool = False,
+             include_partial: bool = True) -> float:
     """
     If ties_win=True, rank will equal a win if tied with an error in error_lst. (ex: rank 1.0)
     If ties_win=False, rank will equal a tie if tied with an error in error_lst. (ex: rank 1.5)
 
     If pct=True, rescales output to be between 0 and 1, with 0 = best, 1 = worst.
+
+    If include_partial=True,
+        a fractional rank between 0 and 0.5 will be added
+        based on the linear distance between the two nearest results in error_lst
+        If error is better than any result, it compares against an error of 0.
+        If error is worse than any result, it compares against an error twice as much as the worst error in error_lst.
+        When True, this increases the worst possible rank by `0.5`.
+        Cannot be True when ties_win=True.
     """
+    if ties_win and include_partial:
+        raise AssertionError('ties_win and include_partial cannot both be True.')
     rank = 0
+    prior_err = 0
+    win = False
     for e in error_lst:
         if error == e:
             # tie
@@ -19,15 +35,30 @@ def get_rank(error: float, error_lst: List[float], higher_is_better: bool = Fals
                 pass  # count as a win
             else:
                 rank += 0.5  # count as a tie
-        elif higher_is_better:
-            if error < e:
-                rank += 1
+        elif error > e:
+            rank += 1
         else:
-            if error > e:
-                rank += 1
+            win = True
+        if win:
+            if include_partial and error != 0:
+                # Add up to 0.5 rank based on distance between closest loss and closest win.
+                partial_rank = ((error - prior_err) / (e - prior_err)) / 2
+                rank += partial_rank
+            # error_lst is assumed to be sorted, so we know that all future elements will be wins
+            # once we find our first win, allowing us to break early
+            break
+        prior_err = e
+    if not win and include_partial and prior_err != 0:
+        # Error is worse than all results,
+        #  double the error of the worst result in error_lst as a new rank to penalize up to 0.5 rank
+        partial_rank = min((error - prior_err) / prior_err, 1) / 2
+        rank += partial_rank
 
     if pct:
-        rank /= len(error_lst)
+        max_rank = len(error_lst)
+        if include_partial:
+            max_rank += 0.5
+        rank /= max_rank
     return rank
 
 
@@ -40,6 +71,7 @@ class RankScorer:
                  framework_col: str = 'framework',
                  ties_win: bool = False,
                  pct: bool = False,
+                 include_partial: bool = True,
                  ):
         """
         :param df_results_by_dataset: Dataframe of method performance containing columns `metric_error_col`,
@@ -54,6 +86,7 @@ class RankScorer:
             assert dataset in all_datasets, f"dataset {dataset} not present in passed evaluations"
         self.ties_win = ties_win
         self.pct = pct
+        self.include_partial = include_partial
         df_pivot = df_results_by_dataset.pivot_table(values=metric_error_col, index=dataset_col, columns=framework_col)
         df_pivot.values.sort(axis=1)
         self.error_dict = {dataset: df_pivot.loc[dataset] for dataset in datasets}
@@ -62,11 +95,15 @@ class RankScorer:
         """
         Get the rank of a result on a dataset given an error.
         """
-        if self.ties_win:
+        if self.ties_win and not self.include_partial:
             rank = np.searchsorted(self.error_dict[dataset], error)
             if self.pct:
                 return rank / len(self.error_dict[dataset])
             else:
                 return rank
         else:
-            return get_rank(error=error, error_lst=self.error_dict[dataset], ties_win=self.ties_win, pct=self.pct)
+            return get_rank(error=error,
+                            error_lst=self.error_dict[dataset],
+                            ties_win=self.ties_win,
+                            pct=self.pct,
+                            include_partial=self.include_partial)

--- a/tst/test_rank_scorer.py
+++ b/tst/test_rank_scorer.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 
 from autogluon_zeroshot.utils.rank_utils import RankScorer
@@ -26,17 +27,20 @@ def test_rank_scorer():
         dataset_col=dataset_col,
         framework_col=framework_col,
         pct=False,
+        include_partial=True,
         ties_win=False,
     )
     query_expected = [
-        (0.8, 0.0),
+        (0.0, 0.0),
+        (0.8, 0.4),
         (1.0, 0.5),
-        (1.5, 1),
+        (1.5, 1.25),
         (2.0, 1.5),
-        (4.0, 3),
+        (4.0, 3.16666666),
+        (8.0, 3.5),
     ]
     for query, expected in query_expected:
-        assert rank_scorer.rank("dataset1", query) == expected
+        assert np.isclose(rank_scorer.rank("dataset1", query), expected)
 
 
 def test_rank_scorer_pct():
@@ -47,19 +51,22 @@ def test_rank_scorer_pct():
         dataset_col=dataset_col,
         framework_col=framework_col,
         pct=True,
+        include_partial=True,
         ties_win=False,
     )
     query_expected = [
-        (0.8, 0.0),
-        (1.0, 1/6),
-        (1.5, 1/3),
-        (2.0, 1/2),
-        (2.5, 2/3),
-        (3.0, 5/6),
-        (4.0, 1.0),
+        (0.0, 0.0),
+        (0.8, 0.1142857142857143),
+        (1.0, 0.14285714285714285),
+        (1.5, 0.35714285714285715),
+        (2.0, 0.42857142857142855),
+        (2.5, 0.6428571428571429),
+        (3.0, 0.7142857142857143),
+        (4.0, 0.9047619047619048),
+        (8.0, 1.0),
     ]
     for query, expected in query_expected:
-        assert rank_scorer.rank("dataset1", query) == expected
+        assert np.isclose(rank_scorer.rank("dataset1", query), expected)
 
 
 def test_rank_scorer_ties_win():
@@ -70,14 +77,17 @@ def test_rank_scorer_ties_win():
         dataset_col=dataset_col,
         framework_col=framework_col,
         ties_win=True,
+        include_partial=False,
         pct=False,
     )
     query_expected = [
+        (0.0, 0),
         (0.8, 0),
         (1.0, 0),
         (1.5, 1),
         (2.0, 1),
         (4.0, 3),
+        (8.0, 3),
     ]
     for query, expected in query_expected:
         assert rank_scorer.rank("dataset1", query) == expected
@@ -91,15 +101,68 @@ def test_rank_scorer_pct_ties_win():
         dataset_col=dataset_col,
         framework_col=framework_col,
         ties_win=True,
+        include_partial=False,
         pct=True,
     )
     query_expected = [
+        (0.0, 0.0),
         (0.8, 0.0),
         (1.0, 0.0),
         (1.5, 1/3),
         (2.0, 1/3),
         (3.0, 2/3),
         (4.0, 1.0),
+        (8.0, 1.0),
+    ]
+    for query, expected in query_expected:
+        assert rank_scorer.rank("dataset1", query) == expected
+
+
+def test_rank_scorer_not_partial():
+    rank_scorer = RankScorer(
+        df_results_by_dataset=df_results_by_dataset,
+        datasets=["dataset1", "dataset2"],
+        metric_error_col=metric_col,
+        dataset_col=dataset_col,
+        framework_col=framework_col,
+        pct=False,
+        include_partial=False,
+        ties_win=False,
+    )
+    query_expected = [
+        (0.0, 0.0),
+        (0.8, 0.0),
+        (1.0, 0.5),
+        (1.5, 1),
+        (2.0, 1.5),
+        (4.0, 3),
+        (8.0, 3),
+    ]
+    for query, expected in query_expected:
+        assert rank_scorer.rank("dataset1", query) == expected
+
+
+def test_rank_scorer_pct_not_partial():
+    rank_scorer = RankScorer(
+        df_results_by_dataset=df_results_by_dataset,
+        datasets=["dataset1", "dataset2"],
+        metric_error_col=metric_col,
+        dataset_col=dataset_col,
+        framework_col=framework_col,
+        pct=True,
+        include_partial=False,
+        ties_win=False,
+    )
+    query_expected = [
+        (0.0, 0.0),
+        (0.8, 0.0),
+        (1.0, 1/6),
+        (1.5, 1/3),
+        (2.0, 1/2),
+        (2.5, 2/3),
+        (3.0, 5/6),
+        (4.0, 1.0),
+        (8.0, 1.0),
     ]
     for query, expected in query_expected:
         assert rank_scorer.rank("dataset1", query) == expected


### PR DESCRIPTION
Added logic for enhanced ranking calculation.

```
    If include_partial=True,
        a fractional rank between 0 and 0.5 will be added
        based on the linear distance between the two nearest results in error_lst
        If error is better than any result, it compares against an error of 0.
        If error is worse than any result, it compares against an error twice as much as the worst error in error_lst.
        When True, this increases the worst possible rank by `0.5`.
```

Previously, scores could get the same rank even if they had different values so long as they didn't win/lose against any additional baselines in `error_lst`.

Now the extent between the gap in performance is taken into account, allowing for a smooth transition of rank, and allowing to capture rank differences for very strong and very weak errors (aka errors better than anything in error_lst or worse than anything in error_lst)

To most easily understand how the logic works, refer to the unit test updates.