### PR TITLE
Add fast_log_loss

### DIFF
--- a/autogluon_zeroshot/metrics/_fast_log_loss.py
+++ b/autogluon_zeroshot/metrics/_fast_log_loss.py
@@ -7,23 +7,45 @@ def extract_true_class_prob(y_true: np.ndarray, y_pred: np.ndarray) -> np.ndarra
     """
     Note: Data must be pre-normalized. The data is not normalized within this function for speed purposes.
     The predictions can then be passed to _fast_log_loss.
-    :param y_true: an array with shape (n_samples,) that contains all the classes, values must be in [0, n_class[
-    :param y_pred: an array with shape (n_samples, n_class) whose values are the prediction probability assigned to the
-    ground truth class
+    :param y_true: an array with shape (n_samples,) that contains all the classes, values must be in [0, n_classes]
+    :param y_pred: an array with shape (n_samples, n_classes) whose values are the prediction probability assigned to
+    the ground truth classes.
     :return: an array with shape (n_samples) that contains the predicted probability of the true class for each sample
     """
-    assert len(y_true) == len(y_pred)
     assert y_pred.ndim == 2
+    assert len(y_true) == len(y_pred)
     return y_pred[range(len(y_pred)), y_true]
 
 
-def mean_log_loss(true_class_prob: np.ndarray) -> float:
+def extract_true_class_prob_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) -> np.ndarray:
+    """
+    Note: Data must be pre-normalized. The data is not normalized within this function for speed purposes.
+    The individual config predictions can then be passed to _fast_log_loss.
+
+    This function is an optimized way to process a batch of config prob predictions, and is faster than calling
+    `extract_true_class_prob` in a for loop.
+
+    :param y_true: an array with shape (n_samples,) that contains all the classes, values must be in [0, n_class[
+    :param y_pred_bulk: an array with shape (n_configs, n_samples, n_classes) whose values are the prediction probability
+    assigned to the ground truth classes for each config/model.
+    :return: an array with shape (n_configs, n_samples) that contains for each config the predicted probability
+    of the true class for each sample.
+    """
+    ndim = y_pred_bulk.ndim
+    if ndim != 3:
+        raise AssertionError(f'Only y_pred_bulk.ndim==3 is valid for this function (ndim={ndim})')
+    assert y_pred_bulk.shape[1] == len(y_true), f"y_true and y_pred_bulk have different numbers of samples! " \
+                                                f"({len(y_true)}, {y_pred_bulk.shape[1]})"
+    return y_pred_bulk[:, range(y_pred_bulk.shape[1]), y_true]
+
+
+def _mean_log_loss(true_class_prob: np.ndarray) -> float:
     return - np.log(true_class_prob).mean()
 
 
-def _fast_log_loss_end_to_end(y_true, y_pred):
+def _fast_log_loss_end_to_end(y_true: np.ndarray, y_pred: np.ndarray) -> float:
     true_class_prob = extract_true_class_prob(y_true=y_true, y_pred=y_pred)
-    return mean_log_loss(true_class_prob=true_class_prob)
+    return _mean_log_loss(true_class_prob=true_class_prob)
 
 
 """
@@ -49,7 +71,7 @@ loss
 """
 # Score function for probabilistic classification
 fast_log_loss = make_scorer('log_loss',
-                            lambda _, true_class_prob: mean_log_loss(true_class_prob),
+                            lambda _, true_class_prob: _mean_log_loss(true_class_prob),
                             optimum=0,
                             greater_is_better=False,
                             needs_proba=True)

--- a/autogluon_zeroshot/metrics/_fast_log_loss.py
+++ b/autogluon_zeroshot/metrics/_fast_log_loss.py
@@ -1,0 +1,83 @@
+from typing import Tuple, Optional
+
+import numpy as np
+
+from autogluon.core.metrics import make_scorer
+
+
+def convert_multi_to_binary_fast_log_loss(y_true: np.ndarray, y_pred: np.ndarray) -> Tuple[None, np.ndarray]:
+    """
+    Converts standard multiclass classification prediction probabilities into a proxy binary format
+    to accelerate log_loss computation.
+
+    The output can be passed into `_fast_log_loss`.
+
+    Note: Data must be pre-normalized. The data is not normalized within this function for speed purposes.
+    """
+    ndim = y_pred.ndim
+    if ndim == 1:
+        raise AssertionError(f'Binary classification not yet implemented for fast_log_loss (it is possible to add)')
+    elif ndim == 2:
+        y_pred = y_pred[range(y_pred.shape[0]), y_true]
+    elif ndim == 3:
+        """Convert multiple model's prediction probabilities at once when stacked in a 3-dimensional numpy array"""
+        y_pred = y_pred[:, range(y_pred.shape[1]), y_true]
+    else:
+        raise AssertionError(f'ndim={ndim} not supported.')
+
+    # This is what y_true is treated as, but no need to perform operation
+    # y_true = np.ones(y_true.shape, dtype=np.uint8)
+
+    return None, y_pred
+
+
+def _fast_log_loss(y_true: Optional[np.ndarray], y_pred: np.ndarray) -> float:
+    """
+    Heavily optimized log_loss implementation that is valid under a specific context and avoids all sanity checks.
+    This is >100x faster than sklearn.
+
+    NOTE: You must first preprocess the input y_pred by calling `convert_multi_to_binary_fast_log_loss`.
+
+    1. There is no epsilon / value clipping, ensure y_pred ranges do not include `0` or `1` to avoid infinite loss.
+    2. `y_true` is ignored. It is assumed to be in the form `np.ones(len(y_pred), dtype=np.uint8)`
+      By assuming this form, we can avoid unnecessary computation.
+    3. `y_pred` must be formatted as a 1-dimensional ndarray.
+      The values are the prediction probability assigned to the ground truth class.
+      All other classes that are not the ground truth are ignored, as they are not necessary to calculate log_loss.
+    4. There is no support for sample weights.
+
+    Parameters
+    ----------
+    y_true : Unused
+        Ignored. y_true is assumed to be `1` for every row.
+
+    y_pred : array-like of float
+        The prediction probabilities of the ground truth class. shape = (n_samples,)
+
+    Returns
+    -------
+    loss
+        The negative log-likelihood
+    """
+    return - np.log(y_pred).mean()
+
+
+def _fast_log_loss_end_to_end(y_true, y_pred):
+    y_true, y_pred = convert_multi_to_binary_fast_log_loss(y_true=y_true, y_pred=y_pred)
+    return _fast_log_loss(y_true=y_true, y_pred=y_pred)
+
+
+# Score function for probabilistic classification
+fast_log_loss = make_scorer('log_loss',
+                            _fast_log_loss,
+                            optimum=0,
+                            greater_is_better=False,
+                            needs_proba=True)
+
+
+# Score function for probabilistic classification
+fast_log_loss_end_to_end = make_scorer('fast_log_loss_end_to_end',
+                                       _fast_log_loss_end_to_end,
+                                       optimum=0,
+                                       greater_is_better=False,
+                                       needs_proba=True)

--- a/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
+++ b/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
@@ -86,8 +86,8 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             #  as a preprocessing step to TabularModelPredictions.
             #  This would avoid ever having to pay the preprocessing time cost, and would massively reduce memory usage.
             eval_metric = _fast_log_loss.fast_log_loss
-            pred_val = _fast_log_loss.extract_true_class_prob(y_true=y_val, y_pred=pred_val)
-            pred_test = _fast_log_loss.extract_true_class_prob(y_true=y_test, y_pred=pred_test)
+            pred_val = _fast_log_loss.extract_true_class_prob_bulk(y_true=y_val, y_pred_bulk=pred_val)
+            pred_test = _fast_log_loss.extract_true_class_prob_bulk(y_true=y_test, y_pred_bulk=pred_test)
         else:
             eval_metric = get_metric(metric_name)
         return eval_metric, y_val, pred_val, y_test, pred_test

--- a/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
+++ b/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
@@ -86,8 +86,8 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             #  as a preprocessing step to TabularModelPredictions.
             #  This would avoid ever having to pay the preprocessing time cost, and would massively reduce memory usage.
             eval_metric = _fast_log_loss.fast_log_loss
-            y_val, pred_val = _fast_log_loss.convert_multi_to_binary_fast_log_loss(y_true=y_val, y_pred=pred_val)
-            y_test, pred_test = _fast_log_loss.convert_multi_to_binary_fast_log_loss(y_true=y_test, y_pred=pred_test)
+            pred_val = _fast_log_loss.extract_true_class_prob(y_true=y_val, y_pred=pred_val)
+            pred_test = _fast_log_loss.extract_true_class_prob(y_true=y_test, y_pred=pred_test)
         else:
             eval_metric = get_metric(metric_name)
         return eval_metric, y_val, pred_val, y_test, pred_test

--- a/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
+++ b/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import ray

--- a/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
+++ b/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List
 
 import numpy as np
 import ray
@@ -10,6 +10,7 @@ from .configuration_list_scorer import ConfigurationListScorer
 from .simulation_context import ZeroshotSimulatorContext
 from .simulation_context import TabularModelPredictions
 from ..utils.rank_utils import RankScorer
+from ..metrics import _fast_log_loss
 
 
 @ray.remote
@@ -31,7 +32,12 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
                  ensemble_selection_kwargs=None,
                  max_fold: Optional[float] = None,
                  backend: str = 'native',
+                 use_fast_metrics: bool = True,
                  ):
+        """
+        TODO: Add docstring
+        :param use_fast_metrics: If True, will leverage optimized eval metrics to speed up config scoring.
+        """
         super(EnsembleSelectionConfigScorer, self).__init__(datasets=datasets)
         if zeroshot_gt is None:
             raise ValueError(f'zeroshot_gt cannot be None!')
@@ -49,6 +55,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         self.max_fold = max_fold
         assert backend in ['native', 'ray']
         self.backend = backend
+        self.use_fast_metrics = use_fast_metrics
 
     @classmethod
     def from_zsc(cls, zeroshot_simulator_context: ZeroshotSimulatorContext, **kwargs):
@@ -59,17 +66,58 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             **kwargs,
         )
 
+    def _get_fast_metric_if_exist(self,
+                                  metric_name: str,
+                                  problem_type: str,
+                                  y_val: np.array,
+                                  pred_val: np.array,
+                                  y_test: np.array,
+                                  pred_test: np.array,
+                                  ):
+        """
+        # TODO: Add docstring
+        # TODO: Consider making this more standardized.
+        #  Currently fast_log_loss needs a bit of special preprocessing of the data and isn't a straightforward replace.
+        # TODO: Add fast_roc_auc
+        # TODO: Add fast_rmse
+        """
+        if metric_name == 'log_loss' and problem_type == 'multiclass':
+            # TODO: Can be even faster if we transform pred_val and pred_test
+            #  as a preprocessing step to TabularModelPredictions.
+            #  This would avoid ever having to pay the preprocessing time cost, and would massively reduce memory usage.
+            eval_metric = _fast_log_loss.fast_log_loss
+            y_val, pred_val = _fast_log_loss.convert_multi_to_binary_fast_log_loss(y_true=y_val, y_pred=pred_val)
+            y_test, pred_test = _fast_log_loss.convert_multi_to_binary_fast_log_loss(y_true=y_test, y_pred=pred_test)
+        else:
+            eval_metric = get_metric(metric_name)
+        return eval_metric, y_val, pred_val, y_test, pred_test
+
     def run_dataset(self, dataset, models):
         fold = self.dataset_name_to_fold_dict[dataset]
         dataset = self.dataset_name_to_tid_dict[dataset]
 
         problem_type = self.zeroshot_gt[dataset][fold]['problem_type']
         metric_name = self.zeroshot_gt[dataset][fold]['eval_metric']
-        eval_metric = get_metric(metric_name)
         y_val = self.zeroshot_gt[dataset][fold]['y_val']
         y_test = self.zeroshot_gt[dataset][fold]['y_test']
 
-        pred_proba_dict_val, pred_proba_dict_test = self.zeroshot_pred_proba.predict(dataset=dataset, fold=fold, splits=['val', 'test'], models=models)
+        y_val = y_val.to_numpy()
+        y_test = y_test.fillna(-1).to_numpy()
+
+        pred_val, pred_test = self.zeroshot_pred_proba.predict(dataset=dataset, fold=fold, splits=['val', 'test'], models=models)
+
+        if self.use_fast_metrics:
+            eval_metric, y_val, pred_val, y_test, pred_test = self._get_fast_metric_if_exist(
+                metric_name=metric_name,
+                problem_type=problem_type,
+                y_val=y_val,
+                pred_val=pred_val,
+                y_test=y_test,
+                pred_test=pred_test,
+            )
+        else:
+            eval_metric = get_metric(metric_name)
+
         weighted_ensemble = EnsembleSelection(
             ensemble_size=self.ensemble_size,
             problem_type=problem_type,
@@ -77,12 +125,11 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             **self.ensemble_selection_kwargs,
         )
 
-        weighted_ensemble.fit(predictions=pred_proba_dict_val, labels=y_val)
+        weighted_ensemble.fit(predictions=pred_val, labels=y_val)
         if eval_metric.needs_pred:
-            y_test_pred = weighted_ensemble.predict(pred_proba_dict_test)
+            y_test_pred = weighted_ensemble.predict(pred_test)
         else:
-            y_test_pred = weighted_ensemble.predict_proba(pred_proba_dict_test)
-        y_test = y_test.fillna(-1)
+            y_test_pred = weighted_ensemble.predict_proba(pred_test)
         err = eval_metric.error(y_test, y_test_pred)
 
         # FIXME

--- a/autogluon_zeroshot/utils/rank_utils.py
+++ b/autogluon_zeroshot/utils/rank_utils.py
@@ -40,7 +40,7 @@ def get_rank(error: float,
         else:
             win = True
         if win:
-            if include_partial and error != 0:
+            if include_partial and error > 0:
                 # Add up to 0.5 rank based on distance between closest loss and closest win.
                 divisor = e - prior_err
                 if divisor == 0:

--- a/scripts/benchmark_metrics/run_bench_log_loss.py
+++ b/scripts/benchmark_metrics/run_bench_log_loss.py
@@ -1,0 +1,188 @@
+import time
+from typing import Tuple
+
+import numpy as np
+
+from autogluon.core.metrics import log_loss
+from sklearn.metrics import log_loss as sk_log_loss
+from autogluon_zeroshot.metrics._fast_log_loss import \
+    fast_log_loss_end_to_end, fast_log_loss, convert_multi_to_binary_fast_log_loss
+from sklearn.preprocessing import normalize
+
+
+def generate_y_true_and_y_pred_proba(num_samples, num_classes, random_seed=0):
+    np.random.seed(seed=random_seed)
+    y_true = np.random.randint(0, num_classes, num_samples)
+    y_pred = np.random.rand(num_samples, num_classes)
+    y_pred = normalize(y_pred, axis=1, norm='l1')
+    return y_true, y_pred
+
+
+def get_eval_speed(*,
+                   eval_metric: callable,
+                   y_true: np.array,
+                   y_pred: np.array,
+                   num_repeats: int) -> Tuple[float, float]:
+    ts = time.time()
+    for _ in range(num_repeats):
+        score = eval_metric(y_true, y_pred)
+    te = time.time()
+    time_average_s = (te - ts) / num_repeats
+    return time_average_s, score
+
+
+def benchmark_log_loss(num_samples: int, num_classes: int, num_repeats: int):
+    """
+    Benchmarks 4 log_loss computing methods, verifying equivalent scores and comparing compute speed
+
+    1. sk_log_loss       : sklearn log_loss, which will be our baseline
+    2. ag_log_loss       : AutoGluon's default log_loss implementation, which is a slightly faster variant to sklearn.
+    3. fast_log_loss_e2e : The end-to-end version of fast log loss.
+        Takes as input the same y_true and y_pred as the above metrics.
+        This can be seen as the time taken to preprocess the data plus the time to pass to `fast_log_loss`.
+    4. fast_log_loss     : The fully optimized fast log loss implementation.
+        This is a very fast implementation whose run-time does not scale with num_classes.
+        Ignores data transformation time, which is valid when re-using y_pred and y_true across many metric calls.
+        y_pred and y_true are re-used many times in the greedy weighted ensemble fit, and thus this technique is valid.
+        Technically for the purposes of ZS simulation, we can run the preprocessing logic on all y_pred for all models,
+        thus never paying the cost of preprocessing and massively reducing memory usage.
+    """
+    print(f'Benchmarking log_loss... (num_samples={num_samples}, num_classes={num_classes}, num_repeats={num_repeats}')
+    y_true, y_pred = generate_y_true_and_y_pred_proba(num_samples=num_samples, num_classes=num_classes)
+
+    benchmark_metrics = [
+        (sk_log_loss, 'sk_log_loss'),
+        (log_loss.error, 'ag_log_loss'),
+        (fast_log_loss_end_to_end.error, 'fast_log_loss_e2e')
+    ]
+
+    baseline_speed = None
+    baseline_score = None
+
+    for eval_metric, func_name in benchmark_metrics:
+        time_average_s, score = get_eval_speed(
+            eval_metric=eval_metric,
+            y_true=y_true,
+            y_pred=y_pred,
+            num_repeats=num_repeats,
+        )
+        if baseline_speed is None:
+            baseline_speed = time_average_s
+        if baseline_score is None:
+            baseline_score = score
+        relative_speedup = baseline_speed / time_average_s
+        print(f'\tTime = {time_average_s*1000:.4f} ms\t'
+              f'| Score = {score}\t'
+              f'| Rel Speedup = {relative_speedup:.1f}x\t| {func_name}')
+        np.testing.assert_allclose(baseline_score, score)
+
+    # fast log loss
+    func_name = 'fast_log_loss'
+
+    # The time this takes can be ignored, as for our purposes this is only paid once,
+    # but y_true_opt and y_pred_opt are re-used in many log_loss calls.
+    y_true_opt, y_pred_opt = convert_multi_to_binary_fast_log_loss(y_true=y_true, y_pred=y_pred)
+
+    time_average_s, score = get_eval_speed(
+        eval_metric=fast_log_loss.error,
+        y_true=y_true_opt,
+        y_pred=y_pred_opt,
+        num_repeats=num_repeats,
+    )
+    relative_speedup = baseline_speed / time_average_s
+    print(f'\tTime = {time_average_s * 1000:.4f} ms\t'
+          f'| Score = {score}\t'
+          f'| Rel Speedup = {relative_speedup:.1f}x\t| {func_name}')
+    np.testing.assert_allclose(baseline_score, score)
+
+
+if __name__ == '__main__':
+    """
+    Run a benchmark demonstrating the result equivalence of `fast_log_loss` with normal `log_loss`,
+    but computed much faster.
+    
+    Below is an example output using an m6i.32xlarge machine. fast_log_loss is at minimum 46x faster than sk_log_loss.
+    
+    Benchmarking log_loss... (num_samples=100, num_classes=2, num_repeats=1000
+        Time = 0.2790 ms	| Score = 0.9403822961581705	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 0.2814 ms	| Score = 0.9403822961581705	| Rel Speedup = 1.0x	| ag_log_loss
+        Time = 0.0142 ms	| Score = 0.9403822961581705	| Rel Speedup = 19.6x	| fast_log_loss_e2e
+        Time = 0.0060 ms	| Score = 0.9403822961581705	| Rel Speedup = 46.5x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=1000, num_classes=2, num_repeats=1000
+        Time = 0.3571 ms	| Score = 0.8685237331905123	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 0.3496 ms	| Score = 0.8685237331905123	| Rel Speedup = 1.0x	| ag_log_loss
+        Time = 0.0631 ms	| Score = 0.8685237331905123	| Rel Speedup = 5.7x	| fast_log_loss_e2e
+        Time = 0.0072 ms	| Score = 0.8685237331905123	| Rel Speedup = 49.9x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=1000, num_classes=10, num_repeats=1000
+        Time = 0.4557 ms	| Score = 2.579619897673683	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 0.4308 ms	| Score = 2.579619897673683	| Rel Speedup = 1.1x	| ag_log_loss
+        Time = 0.0625 ms	| Score = 2.579619897673683	| Rel Speedup = 7.3x	| fast_log_loss_e2e
+        Time = 0.0073 ms	| Score = 2.579619897673683	| Rel Speedup = 62.5x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=1000, num_classes=100, num_repeats=1000
+        Time = 1.2016 ms	| Score = 4.909232424969079	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 1.1516 ms	| Score = 4.909232424969079	| Rel Speedup = 1.0x	| ag_log_loss
+        Time = 0.0625 ms	| Score = 4.909232424969079	| Rel Speedup = 19.2x	| fast_log_loss_e2e
+        Time = 0.0072 ms	| Score = 4.909232424969079	| Rel Speedup = 166.5x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=10000, num_classes=2, num_repeats=100
+        Time = 1.3963 ms	| Score = 0.8916323677552837	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 0.9198 ms	| Score = 0.8916323677552837	| Rel Speedup = 1.5x	| ag_log_loss
+        Time = 0.6123 ms	| Score = 0.8916323677552837	| Rel Speedup = 2.3x	| fast_log_loss_e2e
+        Time = 0.0176 ms	| Score = 0.8916323677552837	| Rel Speedup = 79.5x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=10000, num_classes=10, num_repeats=100
+        Time = 2.5774 ms	| Score = 2.589909918127668	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 1.9414 ms	| Score = 2.589909918127668	| Rel Speedup = 1.3x	| ag_log_loss
+        Time = 0.6366 ms	| Score = 2.589909918127668	| Rel Speedup = 4.0x	| fast_log_loss_e2e
+        Time = 0.0166 ms	| Score = 2.589909918127668	| Rel Speedup = 155.4x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=10000, num_classes=100, num_repeats=100
+        Time = 10.4843 ms	| Score = 4.898674510017278	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 8.8357 ms	| Score = 4.898674510017278	| Rel Speedup = 1.2x	| ag_log_loss
+        Time = 0.6318 ms	| Score = 4.898674510017278	| Rel Speedup = 16.6x	| fast_log_loss_e2e
+        Time = 0.0174 ms	| Score = 4.898674510017278	| Rel Speedup = 602.6x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=100000, num_classes=2, num_repeats=10
+        Time = 12.2029 ms	| Score = 0.8839096911507552	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 6.6070 ms	| Score = 0.8839096911507552	| Rel Speedup = 1.8x	| ag_log_loss
+        Time = 6.2383 ms	| Score = 0.8839096911507552	| Rel Speedup = 2.0x	| fast_log_loss_e2e
+        Time = 0.1235 ms	| Score = 0.8839096911507552	| Rel Speedup = 98.8x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=100000, num_classes=10, num_repeats=10
+        Time = 26.0730 ms	| Score = 2.587538848622231	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 17.5600 ms	| Score = 2.587538848622231	| Rel Speedup = 1.5x	| ag_log_loss
+        Time = 6.3358 ms	| Score = 2.587538848622231	| Rel Speedup = 4.1x	| fast_log_loss_e2e
+        Time = 0.1276 ms	| Score = 2.587538848622231	| Rel Speedup = 204.3x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=100000, num_classes=100, num_repeats=10
+        Time = 150.9778 ms	| Score = 4.915104829696929	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 136.9180 ms	| Score = 4.915104829696929	| Rel Speedup = 1.1x	| ag_log_loss
+        Time = 6.6452 ms	| Score = 4.915104829696929	| Rel Speedup = 22.7x	| fast_log_loss_e2e
+        Time = 0.1232 ms	| Score = 4.915104829696929	| Rel Speedup = 1225.6x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=1000000, num_classes=2, num_repeats=3
+        Time = 146.9060 ms	| Score = 0.8855251809037331	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 142.4049 ms	| Score = 0.8855251809037331	| Rel Speedup = 1.0x	| ag_log_loss
+        Time = 67.7100 ms	| Score = 0.8855251809037331	| Rel Speedup = 2.2x	| fast_log_loss_e2e
+        Time = 1.1628 ms	| Score = 0.8855251809037331	| Rel Speedup = 126.3x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=1000000, num_classes=10, num_repeats=3
+        Time = 304.8170 ms	| Score = 2.593063906209183	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 208.0698 ms	| Score = 2.593063906209183	| Rel Speedup = 1.5x	| ag_log_loss
+        Time = 73.5778 ms	| Score = 2.593063906209183	| Rel Speedup = 4.1x	| fast_log_loss_e2e
+        Time = 1.2427 ms	| Score = 2.593063906209183	| Rel Speedup = 245.3x	| fast_log_loss
+    Benchmarking log_loss... (num_samples=1000000, num_classes=100, num_repeats=3
+        Time = 1507.9544 ms	| Score = 4.911096768402581	| Rel Speedup = 1.0x	| sk_log_loss
+        Time = 1354.8307 ms	| Score = 4.911096768402581	| Rel Speedup = 1.1x	| ag_log_loss
+        Time = 79.2647 ms	| Score = 4.911096768402581	| Rel Speedup = 19.0x	| fast_log_loss_e2e
+        Time = 1.2035 ms	| Score = 4.911096768402581	| Rel Speedup = 1252.9x	| fast_log_loss
+    """
+
+    for num_samples, num_classes, num_repeats in [
+        (100, 2, 1000),
+        (1000, 2, 1000),
+        (1000, 10, 1000),
+        (1000, 100, 1000),
+        (10000, 2, 100),
+        (10000, 10, 100),
+        (10000, 100, 100),
+        (100000, 2, 10),
+        (100000, 10, 10),
+        (100000, 100, 10),
+        (1000000, 2, 3),
+        (1000000, 10, 3),
+        (1000000, 100, 3),
+    ]:
+        benchmark_log_loss(num_samples=num_samples, num_classes=num_classes, num_repeats=num_repeats)

--- a/scripts/benchmark_metrics/run_bench_log_loss.py
+++ b/scripts/benchmark_metrics/run_bench_log_loss.py
@@ -6,7 +6,7 @@ import numpy as np
 from autogluon.core.metrics import log_loss
 from sklearn.metrics import log_loss as sk_log_loss
 from autogluon_zeroshot.metrics._fast_log_loss import \
-    fast_log_loss_end_to_end, fast_log_loss, convert_multi_to_binary_fast_log_loss
+    fast_log_loss_end_to_end, fast_log_loss, extract_true_class_prob
 from sklearn.preprocessing import normalize
 
 
@@ -81,11 +81,11 @@ def benchmark_log_loss(num_samples: int, num_classes: int, num_repeats: int):
 
     # The time this takes can be ignored, as for our purposes this is only paid once,
     # but y_true_opt and y_pred_opt are re-used in many log_loss calls.
-    y_true_opt, y_pred_opt = convert_multi_to_binary_fast_log_loss(y_true=y_true, y_pred=y_pred)
+    y_pred_opt = extract_true_class_prob(y_true=y_true, y_pred=y_pred)
 
     time_average_s, score = get_eval_speed(
         eval_metric=fast_log_loss.error,
-        y_true=y_true_opt,
+        y_true=y_true,
         y_pred=y_pred_opt,
         num_repeats=num_repeats,
     )

--- a/tst/test_metrics.py
+++ b/tst/test_metrics.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+import sklearn
+from sklearn.preprocessing import normalize
+from autogluon.core.metrics import log_loss
+
+from autogluon_zeroshot.metrics import _fast_log_loss
+
+
+def generate_y_true_and_y_pred_proba(num_samples, num_classes, random_seed=0):
+    np.random.seed(seed=random_seed)
+    y_true = np.random.randint(0, num_classes, num_samples)
+    y_pred = np.random.rand(num_samples, num_classes)
+    y_pred = normalize(y_pred, axis=1, norm='l1')
+    return y_true, y_pred
+
+
+@pytest.mark.parametrize('y_true,y_pred',
+                         [([0, 2, 1, 1],
+                           [[0.1, 0.2, 0.7],
+                            [0.2, 0.1, 0.7],
+                            [0.3, 0.4, 0.3],
+                            [0.01, 0.9, 0.09]])])
+def test_fast_log_loss(y_true, y_pred):
+    """Ensure fast_log_loss produces equivalent scores to AutoGluon and Scikit-Learn log_loss implementations"""
+    y_true = np.array(y_true, dtype=np.int64)
+    y_pred = np.array(y_pred, dtype=np.float32)
+    ag_loss = log_loss(y_true, y_pred)
+    sk_loss = -sklearn.metrics.log_loss(y_true, y_pred)
+    np.testing.assert_allclose(ag_loss, sk_loss)
+
+    y_true_opt, y_pred_opt = _fast_log_loss.convert_multi_to_binary_fast_log_loss(y_true, y_pred)
+    fast_loss = _fast_log_loss.fast_log_loss(y_true_opt, y_pred_opt)
+    fast_loss_end_to_end = _fast_log_loss.fast_log_loss_end_to_end(y_true, y_pred)
+
+    np.testing.assert_allclose(ag_loss, fast_loss)
+    np.testing.assert_allclose(ag_loss, fast_loss_end_to_end)
+
+
+@pytest.mark.parametrize('num_samples,num_classes',
+                         [
+                             (1, 2),
+                             (1, 10),
+                             (1000, 2),
+                             (1000, 10),
+                             (10000, 2),
+                             (10000, 100),
+                         ])
+def test_fast_log_loss_large(num_samples, num_classes):
+    """
+    Ensure fast_log_loss produces equivalent scores to AutoGluon and Scikit-Learn log_loss implementations
+    across various data dimensions.
+    """
+    y_true, y_pred = generate_y_true_and_y_pred_proba(num_samples=num_samples, num_classes=num_classes)
+
+    ag_loss = log_loss(y_true, y_pred)
+    sk_loss = -sklearn.metrics.log_loss(y_true, y_pred, labels=list(range(num_classes)))
+    np.testing.assert_allclose(ag_loss, sk_loss)
+
+    y_true_opt, y_pred_opt = _fast_log_loss.convert_multi_to_binary_fast_log_loss(y_true, y_pred)
+    fast_loss = _fast_log_loss.fast_log_loss(y_true_opt, y_pred_opt)
+    fast_loss_end_to_end = _fast_log_loss.fast_log_loss_end_to_end(y_true, y_pred)
+
+    np.testing.assert_allclose(ag_loss, fast_loss)
+    np.testing.assert_allclose(ag_loss, fast_loss_end_to_end)

--- a/tst/test_metrics.py
+++ b/tst/test_metrics.py
@@ -15,6 +15,14 @@ def generate_y_true_and_y_pred_proba(num_samples, num_classes, random_seed=0):
     return y_true, y_pred
 
 
+def generate_y_true_and_y_pred_proba_bulk(num_configs, num_samples, num_classes, random_seed=0):
+    np.random.seed(seed=random_seed)
+    y_true = np.random.randint(0, num_classes, num_samples)
+    y_pred_bulk = [normalize(np.random.rand(num_samples, num_classes), axis=1, norm='l1') for _ in range(num_configs)]
+    y_pred_bulk = np.array(y_pred_bulk)
+    return y_true, y_pred_bulk
+
+
 @pytest.mark.parametrize('y_true,y_pred',
                          [([0, 2, 1, 1],
                            [[0.1, 0.2, 0.7],
@@ -27,6 +35,19 @@ def test_fast_log_loss(y_true, y_pred):
     y_pred = np.array(y_pred, dtype=np.float32)
     ag_loss = log_loss(y_true, y_pred)
     sk_loss = -sklearn.metrics.log_loss(y_true, y_pred)
+    np.testing.assert_allclose(ag_loss, sk_loss)
+
+    y_pred_opt = _fast_log_loss.extract_true_class_prob(y_true, y_pred)
+    fast_loss = _fast_log_loss.fast_log_loss(y_true, y_pred_opt)
+    fast_loss_end_to_end = _fast_log_loss.fast_log_loss_end_to_end(y_true, y_pred)
+
+    np.testing.assert_allclose(ag_loss, fast_loss)
+    np.testing.assert_allclose(ag_loss, fast_loss_end_to_end)
+
+
+def assert_fast_log_loss_equivalence(y_true, y_pred, num_classes):
+    ag_loss = log_loss(y_true, y_pred)
+    sk_loss = -sklearn.metrics.log_loss(y_true, y_pred, labels=list(range(num_classes)))
     np.testing.assert_allclose(ag_loss, sk_loss)
 
     y_pred_opt = _fast_log_loss.extract_true_class_prob(y_true, y_pred)
@@ -52,14 +73,51 @@ def test_fast_log_loss_large(num_samples, num_classes):
     across various data dimensions.
     """
     y_true, y_pred = generate_y_true_and_y_pred_proba(num_samples=num_samples, num_classes=num_classes)
+    assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred, num_classes=num_classes)
 
-    ag_loss = log_loss(y_true, y_pred)
-    sk_loss = -sklearn.metrics.log_loss(y_true, y_pred, labels=list(range(num_classes)))
-    np.testing.assert_allclose(ag_loss, sk_loss)
 
-    y_pred_opt = _fast_log_loss.extract_true_class_prob(y_true, y_pred)
-    fast_loss = _fast_log_loss.fast_log_loss(y_true, y_pred_opt)
-    fast_loss_end_to_end = _fast_log_loss.fast_log_loss_end_to_end(y_true, y_pred)
+@pytest.mark.parametrize('num_configs,num_samples,num_classes',
+                         [
+                             (1, 1, 2),
+                             (2, 1, 2),
+                             (10, 1, 2),
+                             (10, 1, 10),
+                             (1, 1000, 2),
+                             (10, 1000, 10),
+                             (100, 1000, 10),
+                             (10, 10000, 2),
+                             (10, 10000, 100),
+                         ])
+def test_fast_log_loss_bulk(num_configs, num_samples, num_classes):
+    """
+    Ensure fast_log_loss produces equivalent scores to AutoGluon and Scikit-Learn log_loss implementations
+    in the scenario where we have multiple configs and potentially weight them.
+    This verifies we can perform operations such as config weighting
+    to the optimized predictions and still obtain equivalent log_loss results.
+    """
+    y_true, y_pred_bulk = generate_y_true_and_y_pred_proba_bulk(
+        num_configs=num_configs,
+        num_samples=num_samples,
+        num_classes=num_classes
+    )
 
-    np.testing.assert_allclose(ag_loss, fast_loss)
-    np.testing.assert_allclose(ag_loss, fast_loss_end_to_end)
+    for i in range(num_configs):
+        y_pred = y_pred_bulk[i]
+        assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred, num_classes=num_classes)
+
+    config_weights = np.random.rand(num_configs)
+    config_weights /= np.sum(config_weights)
+    np.testing.assert_allclose(np.sum(config_weights), 1)
+
+    y_pred_bulk_weighted = [pred * weight for pred, weight in zip(y_pred_bulk, config_weights)]
+    y_pred_ensemble = np.sum(y_pred_bulk_weighted, axis=0)
+    assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred_ensemble, num_classes=num_classes)
+
+    y_pred_bulk_opt = _fast_log_loss.extract_true_class_prob_bulk(y_true, y_pred_bulk)
+    y_pred_bulk_opt_weighted = [pred * weight for pred, weight in zip(y_pred_bulk_opt, config_weights)]
+
+    y_pred_opt_ensemble = np.sum(y_pred_bulk_opt_weighted, axis=0)
+    fast_loss_ensemble = _fast_log_loss.fast_log_loss(y_true, y_pred_opt_ensemble)
+    ag_loss_ensemble = log_loss(y_true, y_pred_ensemble)
+
+    np.testing.assert_allclose(ag_loss_ensemble, fast_loss_ensemble)

--- a/tst/test_metrics.py
+++ b/tst/test_metrics.py
@@ -29,8 +29,8 @@ def test_fast_log_loss(y_true, y_pred):
     sk_loss = -sklearn.metrics.log_loss(y_true, y_pred)
     np.testing.assert_allclose(ag_loss, sk_loss)
 
-    y_true_opt, y_pred_opt = _fast_log_loss.convert_multi_to_binary_fast_log_loss(y_true, y_pred)
-    fast_loss = _fast_log_loss.fast_log_loss(y_true_opt, y_pred_opt)
+    y_pred_opt = _fast_log_loss.extract_true_class_prob(y_true, y_pred)
+    fast_loss = _fast_log_loss.fast_log_loss(y_true, y_pred_opt)
     fast_loss_end_to_end = _fast_log_loss.fast_log_loss_end_to_end(y_true, y_pred)
 
     np.testing.assert_allclose(ag_loss, fast_loss)
@@ -57,8 +57,8 @@ def test_fast_log_loss_large(num_samples, num_classes):
     sk_loss = -sklearn.metrics.log_loss(y_true, y_pred, labels=list(range(num_classes)))
     np.testing.assert_allclose(ag_loss, sk_loss)
 
-    y_true_opt, y_pred_opt = _fast_log_loss.convert_multi_to_binary_fast_log_loss(y_true, y_pred)
-    fast_loss = _fast_log_loss.fast_log_loss(y_true_opt, y_pred_opt)
+    y_pred_opt = _fast_log_loss.extract_true_class_prob(y_true, y_pred)
+    fast_loss = _fast_log_loss.fast_log_loss(y_true, y_pred_opt)
     fast_loss_end_to_end = _fast_log_loss.fast_log_loss_end_to_end(y_true, y_pred)
 
     np.testing.assert_allclose(ag_loss, fast_loss)


### PR DESCRIPTION
Accelerates `log_loss` (Related to #20)

Added fast_log_loss, which is at minimum 46x faster and up-to 1200x faster than native sklearn log_loss.

This ends up accelerating multiclass ZS ensemble simulation by 25x+:

Mainline (~12s added per iteration):
```

1	: Train: 3.24 | 8.7s	| Tr Change: 2.994	| Conf Options: 608	| ray | CatBoost_r84_BAG_L1
2	: Train: 2.5 | 31.52s	| Tr Change: 0.731	| Conf Options: 607	| ray | NeuralNetFastAI_r173_BAG_L1
3	: Train: 2.24 | 43.13s	| Tr Change: 0.268	| Conf Options: 606	| ray | RandomForest_r7_BAG_L1
4	: Train: 2.08 | 54.68s	| Tr Change: 0.160	| Conf Options: 605	| ray | LightGBM_r138_BAG_L1
5	: Train: 1.95 | 66.5s	| Tr Change: 0.124	| Conf Options: 604	| ray | CatBoost_r46_BAG_L1
6	: Train: 1.86 | 77.52s	| Tr Change: 0.093	| Conf Options: 603	| ray | NeuralNetFastAI_r52_BAG_L1
7	: Train: 1.81 | 89.45s	| Tr Change: 0.047	| Conf Options: 602	| ray | NeuralNetFastAI_r34_BAG_L1
8	: Train: 1.76 | 100.63s	| Tr Change: 0.049	| Conf Options: 601	| ray | ExtraTrees_r9_BAG_L1
9	: Train: 1.73 | 112.7s	| Tr Change: 0.035	| Conf Options: 600	| ray | NeuralNetFastAI_r35_BAG_L1
10	: Train: 1.71 | 124.08s	| Tr Change: 0.023	| Conf Options: 599	| ray | NeuralNetFastAI_r152_BAG_L1
selected ['CatBoost_r84_BAG_L1', 'NeuralNetFastAI_r173_BAG_L1', 'RandomForest_r7_BAG_L1', 'LightGBM_r138_BAG_L1', 'CatBoost_r46_BAG_L1', 'NeuralNetFastAI_r52_BAG_L1', 'NeuralNetFastAI_r34_BAG_L1', 'ExtraTrees_r9_BAG_L1', 'NeuralNetFastAI_r35_BAG_L1', 'NeuralNetFastAI_r152_BAG_L1']
test_score: 2.0691958948425495
```

This PR (~0.4s added per iteration):
```
1	: Train: 3.24 | 7.2s	| Tr Change: 2.994	| Conf Options: 608	| ray | CatBoost_r84_BAG_L1
2	: Train: 2.5 | 7.47s	| Tr Change: 0.731	| Conf Options: 607	| ray | NeuralNetFastAI_r173_BAG_L1
3	: Train: 2.24 | 8.0s	| Tr Change: 0.268	| Conf Options: 606	| ray | RandomForest_r7_BAG_L1
4	: Train: 2.08 | 8.43s	| Tr Change: 0.160	| Conf Options: 605	| ray | LightGBM_r138_BAG_L1
5	: Train: 1.95 | 8.82s	| Tr Change: 0.124	| Conf Options: 604	| ray | CatBoost_r46_BAG_L1
6	: Train: 1.86 | 9.41s	| Tr Change: 0.093	| Conf Options: 603	| ray | NeuralNetFastAI_r52_BAG_L1
7	: Train: 1.81 | 9.83s	| Tr Change: 0.047	| Conf Options: 602	| ray | NeuralNetFastAI_r34_BAG_L1
8	: Train: 1.76 | 10.19s	| Tr Change: 0.049	| Conf Options: 601	| ray | ExtraTrees_r9_BAG_L1
9	: Train: 1.73 | 10.79s	| Tr Change: 0.035	| Conf Options: 600	| ray | NeuralNetFastAI_r35_BAG_L1
10	: Train: 1.71 | 11.13s	| Tr Change: 0.023	| Conf Options: 599	| ray | NeuralNetFastAI_r152_BAG_L1
selected ['CatBoost_r84_BAG_L1', 'NeuralNetFastAI_r173_BAG_L1', 'RandomForest_r7_BAG_L1', 'LightGBM_r138_BAG_L1', 'CatBoost_r46_BAG_L1', 'NeuralNetFastAI_r52_BAG_L1', 'NeuralNetFastAI_r34_BAG_L1', 'ExtraTrees_r9_BAG_L1', 'NeuralNetFastAI_r35_BAG_L1', 'NeuralNetFastAI_r152_BAG_L1']
test_score: 2.0691951605673684
```