### PR TITLE
Add fast_roc_auc

### DIFF
--- a/autogluon_zeroshot/metrics/_fast_roc_auc.py
+++ b/autogluon_zeroshot/metrics/_fast_roc_auc.py
@@ -1,0 +1,12 @@
+from autogluon.core.metrics import make_scorer
+
+from ._roc_auc_cpp import CppAuc
+
+
+# TODO: Consider having `setup.py` automatically compile the C++ code to avoid having to manually do so.
+# Score functions that need decision values
+# Requires compiled C++ code, refer to `_roc_auc_cpp/README.md` for details
+fast_roc_auc_cpp = make_scorer('roc_auc',
+                               CppAuc().roc_auc_score,
+                               greater_is_better=True,
+                               needs_threshold=True)

--- a/autogluon_zeroshot/metrics/_roc_auc_cpp/LICENSE.md
+++ b/autogluon_zeroshot/metrics/_roc_auc_cpp/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Vsevolod Kompantsev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/autogluon_zeroshot/metrics/_roc_auc_cpp/README.md
+++ b/autogluon_zeroshot/metrics/_roc_auc_cpp/README.md
@@ -1,0 +1,13 @@
+This C++ implementation of ROC_AUC is based on the code from https://github.com/diditforlulz273/fastauc,
+with some additional optimizations.
+
+You can find the original MIT license included within this folder (`LICENSE.md`).
+
+## Compile
+
+To compile, run `./compile.sh`.
+
+## Changes
+
+To accelerate the code beyond the original implementation, `sample_weights` support was removed.
+Additionally, the return type was changed from `float` to `double` for enhanced precision.

--- a/autogluon_zeroshot/metrics/_roc_auc_cpp/__init__.py
+++ b/autogluon_zeroshot/metrics/_roc_auc_cpp/__init__.py
@@ -1,0 +1,38 @@
+import ctypes
+import os
+import numpy as np
+from numpy.ctypeslib import ndpointer
+
+
+class CppAuc:
+    """A python wrapper class for a C++ library, used to load it once and make fast calls after.
+    NB be aware of data types accepted, see method docstrings.
+    """
+
+    def __init__(self):
+        try:
+            self._handle = ctypes.CDLL(os.path.dirname(os.path.realpath(__file__)) + os.path.sep + "cpp_auc.so")
+        except OSError:
+            command_to_compile = f"cd {os.path.dirname(os.path.realpath(__file__))} && .{os.path.sep}compile.sh"
+            raise OSError(f'Missing cpp_auc.so compiled file... '
+                          f'You must first compile the C++ code to use this metric. '
+                          f'Run the below terminal command to compile the code:\n'
+                          f'{command_to_compile}')
+        self._handle.cpp_auc_ext.argtypes = [ndpointer(ctypes.c_float, flags="C_CONTIGUOUS"),
+                                             ndpointer(ctypes.c_bool, flags="C_CONTIGUOUS"),
+                                             ctypes.c_size_t
+                                             ]
+        self._handle.cpp_auc_ext.restype = ctypes.c_double
+
+    def roc_auc_score(self, y_true: np.array, y_score: np.array) -> float:
+        """a method to calculate AUC via C++ lib.
+        Args:
+            y_true (np.array): 1D numpy array of dtype=np.bool8 as true labels.
+            y_score (np.array): 1D numpy array of dtype=np.float32 as probability predictions.
+            sample_weight (np.array): 1D numpy array as sample weights, optional.
+        Returns:
+            float: AUC score
+        """
+        n = len(y_true)
+        result = self._handle.cpp_auc_ext(y_score.astype(np.float32), y_true, n)
+        return result

--- a/autogluon_zeroshot/metrics/_roc_auc_cpp/compile.sh
+++ b/autogluon_zeroshot/metrics/_roc_auc_cpp/compile.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+g++ -shared -O3 -march=native cpp_auc.cpp -o cpp_auc.so

--- a/autogluon_zeroshot/metrics/_roc_auc_cpp/cpp_auc.cpp
+++ b/autogluon_zeroshot/metrics/_roc_auc_cpp/cpp_auc.cpp
@@ -1,0 +1,66 @@
+#include <vector>
+#include <iostream>
+#include <algorithm>
+#include <tuple>
+#include <type_traits>
+
+
+// Code based on https://github.com/diditforlulz273/fastauc , which is under MIT license
+
+// Fill the zipped vector with pairs consisting of the
+// corresponding elements of a and b. (This assumes
+// that the vectors have equal length)
+template <typename tuple_type> void zip(
+    const bool* a,
+    const float* b,
+    const size_t len,
+    std::vector<tuple_type> &zipped)
+    {
+        for(size_t i=0; i<len; ++i)
+        {
+            zipped.push_back(std::make_tuple(a[i], b[i]));
+        }
+    }
+
+double trapezoid_area(double x1, double x2, double y1, double y2) {
+  double dx = x2 - x1;
+  double dy = y2 - y1;
+  return dx * y1 + dy * dx / 2.0;
+}
+
+template <typename tuple_type> double auc_kernel(float* ts, bool* st, size_t len) {
+  // sort the data
+  // Zip the vectors together
+  std::vector<tuple_type> zipped;
+  zipped.reserve(len);
+  zip<tuple_type>(st, ts, len, zipped);
+
+  // Sort the vector of pairs
+  std::sort(std::begin(zipped), std::end(zipped),
+    [&](const auto& a, const auto& b)
+    {
+        return std::get<1>(a) > std::get<1>(b);
+    });
+
+  double fps = 0;
+  double tps = 0;
+  double last_counted_fps = 0;
+  double last_counted_tps = 0;
+  double auc = 0;
+  for (size_t i=0; i < zipped.size(); ++i) {
+    tps += std::get<0>(zipped[i]);
+    fps += (1 - std::get<0>(zipped[i]));
+    if ((i == zipped.size() - 1) || (std::get<1>(zipped[i+1]) != std::get<1>(zipped[i]))) {
+        auc += trapezoid_area(last_counted_fps, fps, last_counted_tps, tps);
+        last_counted_fps = fps;
+        last_counted_tps = tps;
+    }
+  }
+  return auc / (tps * fps);
+}
+
+extern "C" {
+    double cpp_auc_ext(float* ts, bool* st, size_t len) {
+        return auc_kernel<std::tuple<bool, float>>(ts, st, len);
+    }
+}

--- a/autogluon_zeroshot/metrics/bench_utils.py
+++ b/autogluon_zeroshot/metrics/bench_utils.py
@@ -1,0 +1,85 @@
+"""Utilities for benchmarking the speed of evaluation metrics."""
+from typing import List, Tuple
+import time
+
+import numpy as np
+from sklearn.preprocessing import normalize
+
+
+def generate_y_true_and_y_pred_binary(num_samples, random_seed=0):
+    np.random.seed(seed=random_seed)
+    y_true = np.random.randint(0, 2, num_samples).astype(np.bool8)
+    y_pred = np.random.rand(num_samples).astype(np.float32)
+    return y_true, y_pred
+
+
+def generate_y_true_and_y_pred_proba(num_samples, num_classes, random_seed=0):
+    np.random.seed(seed=random_seed)
+    y_true = np.random.randint(0, num_classes, num_samples).astype(np.uint16)
+    y_pred = np.random.rand(num_samples, num_classes)
+    y_pred = normalize(y_pred, axis=1, norm='l1').astype(np.float32)
+    return y_true, y_pred
+
+
+def generate_y_true_and_y_pred_proba_bulk(num_configs, num_samples, num_classes, random_seed=0):
+    np.random.seed(seed=random_seed)
+    y_true = np.random.randint(0, num_classes, num_samples)
+    y_pred_bulk = [normalize(np.random.rand(num_samples, num_classes), axis=1, norm='l1') for _ in range(num_configs)]
+    y_pred_bulk = np.array(y_pred_bulk)
+    return y_true, y_pred_bulk
+
+
+def get_eval_speed(*,
+                   eval_metric: callable,
+                   y_true: np.array,
+                   y_pred: np.array,
+                   num_repeats: int) -> Tuple[float, float]:
+    score = None
+    ts = time.time()
+    for _ in range(num_repeats):
+        score = eval_metric(y_true, y_pred)
+    te = time.time()
+    time_average_s = (te - ts) / num_repeats
+    return time_average_s, score
+
+
+def print_benchmark_result(*,
+                           baseline_speed: float,
+                           time_average_s: float,
+                           score: float,
+                           func_name: str):
+    relative_speedup = baseline_speed / time_average_s
+    print(f'\tTime = {time_average_s * 1000:.4f} ms\t'
+          f'| Rel Speedup = {relative_speedup:.1f}x\t'
+          f'| Score = {score}\t'
+          f'| {func_name}')
+
+
+def benchmark_metrics_speed(y_true: np.array,
+                            y_pred: np.array,
+                            benchmark_metrics: List[Tuple[callable, str]],
+                            num_repeats: int,
+                            assert_score_isclose: bool = True,
+                            rtol: float = 1e-7) -> Tuple[float, float]:
+    baseline_speed = None
+    baseline_score = None
+
+    for eval_metric, func_name in benchmark_metrics:
+        time_average_s, score = get_eval_speed(
+            eval_metric=eval_metric,
+            y_true=y_true,
+            y_pred=y_pred,
+            num_repeats=num_repeats,
+        )
+        if baseline_speed is None:
+            baseline_speed = time_average_s
+        if baseline_score is None:
+            baseline_score = score
+
+        print_benchmark_result(baseline_speed=baseline_speed,
+                               time_average_s=time_average_s,
+                               score=score,
+                               func_name=func_name)
+        if assert_score_isclose:
+            np.testing.assert_allclose(baseline_score, score, rtol=rtol)
+    return baseline_speed, baseline_score

--- a/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
+++ b/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
@@ -88,6 +88,17 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             eval_metric = _fast_log_loss.fast_log_loss
             pred_val = _fast_log_loss.extract_true_class_prob_bulk(y_true=y_val, y_pred_bulk=pred_val)
             pred_test = _fast_log_loss.extract_true_class_prob_bulk(y_true=y_test, y_pred_bulk=pred_test)
+        elif metric_name == 'roc_auc':
+            """
+            Lazy import since this requires to compile C++ code prior to work.
+            Will raise an OSError on import if the compiled code isn't present.
+            """
+            from ..metrics import _fast_roc_auc
+            y_val = y_val.astype(np.bool8)
+            y_test = y_test.astype(np.bool8)
+            pred_val = pred_val.astype(np.float32)
+            pred_test = pred_test.astype(np.float32)
+            eval_metric = _fast_roc_auc.fast_roc_auc_cpp
         else:
             eval_metric = get_metric(metric_name)
         return eval_metric, y_val, pred_val, y_test, pred_test

--- a/scripts/benchmark_metrics/run_bench_roc_auc.py
+++ b/scripts/benchmark_metrics/run_bench_roc_auc.py
@@ -1,0 +1,40 @@
+from sklearn.metrics import roc_auc_score
+
+from autogluon.core.metrics import roc_auc
+from autogluon_zeroshot.metrics._fast_roc_auc import fast_roc_auc_cpp
+from autogluon_zeroshot.metrics.bench_utils import benchmark_metrics_speed, generate_y_true_and_y_pred_binary
+
+
+def benchmark_root_mean_squared_error(num_samples: int, num_repeats: int):
+    """
+    Requires compiling C++ code to run `fast_roc_auc_cpp`
+    """
+    print(f'Benchmarking roc_auc... (num_samples={num_samples}, num_repeats={num_repeats}')
+    y_true, y_pred = generate_y_true_and_y_pred_binary(num_samples=num_samples)
+    benchmark_metrics = [
+        (roc_auc_score, 'sk_roc_auc'),
+        (roc_auc, 'ag_roc_auc'),
+        (fast_roc_auc_cpp, 'fast_roc_auc_cpp'),
+    ]
+    benchmark_metrics_speed(
+        y_true=y_true,
+        y_pred=y_pred,
+        benchmark_metrics=benchmark_metrics,
+        num_repeats=num_repeats,
+        assert_score_isclose=True,
+    )
+
+
+if __name__ == '__main__':
+    for num_samples, num_repeats in [
+        (2, 1000),
+        (10, 1000),
+        (100, 1000),
+        (1000, 1000),
+        (2000, 1000),
+        (5000, 100),
+        (10000, 100),
+        (100000, 20),
+        (1000000, 3),
+    ]:
+        benchmark_root_mean_squared_error(num_samples=num_samples, num_repeats=num_repeats)

--- a/tst/test_metrics.py
+++ b/tst/test_metrics.py
@@ -1,26 +1,11 @@
 import numpy as np
 import pytest
 import sklearn
-from sklearn.preprocessing import normalize
-from autogluon.core.metrics import log_loss
+from autogluon.core.metrics import log_loss, roc_auc
 
-from autogluon_zeroshot.metrics import _fast_log_loss
-
-
-def generate_y_true_and_y_pred_proba(num_samples, num_classes, random_seed=0):
-    np.random.seed(seed=random_seed)
-    y_true = np.random.randint(0, num_classes, num_samples)
-    y_pred = np.random.rand(num_samples, num_classes)
-    y_pred = normalize(y_pred, axis=1, norm='l1')
-    return y_true, y_pred
-
-
-def generate_y_true_and_y_pred_proba_bulk(num_configs, num_samples, num_classes, random_seed=0):
-    np.random.seed(seed=random_seed)
-    y_true = np.random.randint(0, num_classes, num_samples)
-    y_pred_bulk = [normalize(np.random.rand(num_samples, num_classes), axis=1, norm='l1') for _ in range(num_configs)]
-    y_pred_bulk = np.array(y_pred_bulk)
-    return y_true, y_pred_bulk
+from autogluon_zeroshot.metrics import _fast_log_loss, _fast_roc_auc
+from autogluon_zeroshot.metrics.bench_utils import generate_y_true_and_y_pred_proba, \
+    generate_y_true_and_y_pred_proba_bulk, generate_y_true_and_y_pred_binary
 
 
 @pytest.mark.parametrize('y_true,y_pred',
@@ -33,29 +18,55 @@ def test_fast_log_loss(y_true, y_pred):
     """Ensure fast_log_loss produces equivalent scores to AutoGluon and Scikit-Learn log_loss implementations"""
     y_true = np.array(y_true, dtype=np.int64)
     y_pred = np.array(y_pred, dtype=np.float32)
-    ag_loss = log_loss(y_true, y_pred)
-    sk_loss = -sklearn.metrics.log_loss(y_true, y_pred)
-    np.testing.assert_allclose(ag_loss, sk_loss)
 
-    y_pred_opt = _fast_log_loss.extract_true_class_prob(y_true, y_pred)
-    fast_loss = _fast_log_loss.fast_log_loss(y_true, y_pred_opt)
-    fast_loss_end_to_end = _fast_log_loss.fast_log_loss_end_to_end(y_true, y_pred)
-
-    np.testing.assert_allclose(ag_loss, fast_loss)
-    np.testing.assert_allclose(ag_loss, fast_loss_end_to_end)
+    assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred, num_classes=y_pred.shape[1], rtol=1e-6)
 
 
-def assert_fast_log_loss_equivalence(y_true, y_pred, num_classes):
+def assert_fast_log_loss_equivalence(y_true, y_pred, num_classes, rtol=1e-7):
     ag_loss = log_loss(y_true, y_pred)
     sk_loss = -sklearn.metrics.log_loss(y_true, y_pred, labels=list(range(num_classes)))
-    np.testing.assert_allclose(ag_loss, sk_loss)
+    np.testing.assert_allclose(ag_loss, sk_loss, rtol=rtol)
 
     y_pred_opt = _fast_log_loss.extract_true_class_prob(y_true, y_pred)
     fast_loss = _fast_log_loss.fast_log_loss(y_true, y_pred_opt)
     fast_loss_end_to_end = _fast_log_loss.fast_log_loss_end_to_end(y_true, y_pred)
 
-    np.testing.assert_allclose(ag_loss, fast_loss)
-    np.testing.assert_allclose(ag_loss, fast_loss_end_to_end)
+    np.testing.assert_allclose(ag_loss, fast_loss, rtol=rtol)
+    np.testing.assert_allclose(ag_loss, fast_loss_end_to_end, rtol=rtol)
+
+
+def assert_fast_roc_auc_equivalence(y_true, y_pred, rtol=1e-7):
+    ag_score = roc_auc(y_true, y_pred)
+    sk_score = sklearn.metrics.roc_auc_score(y_true, y_pred)
+    np.testing.assert_allclose(ag_score, sk_score, rtol=rtol)
+
+    fast_score = _fast_roc_auc.fast_roc_auc_cpp(y_true, y_pred)
+    np.testing.assert_allclose(ag_score, fast_score, rtol=rtol)
+
+
+@pytest.mark.parametrize('y_true,y_pred',
+                         [
+                            ([0, 1, 0, 0], [0.6, 0.5, 0.4, 0.3]),
+                            ([0, 1, 0, 0], [0.5, 0.5, 0.6, 0.6]),
+                         ])
+def test_fast_roc_auc_ties(y_true, y_pred):
+    """Ensure fast_roc_auc produces equivalent scores to AutoGluon and Scikit-Learn roc_auc implementations
+    when ties exist"""
+    y_true = np.array(y_true, dtype=np.bool8)
+    y_pred = np.array(y_pred, dtype=np.float32)
+    assert_fast_roc_auc_equivalence(y_true=y_true, y_pred=y_pred)
+
+
+@pytest.mark.parametrize('num_samples',
+                         [
+                             100,
+                             1000,
+                             10000,
+                             100000,
+                         ])
+def test_fast_roc_auc_large(num_samples):
+    y_true, y_pred = generate_y_true_and_y_pred_binary(num_samples=num_samples)
+    assert_fast_roc_auc_equivalence(y_true=y_true, y_pred=y_pred)
 
 
 @pytest.mark.parametrize('num_samples,num_classes',
@@ -73,7 +84,7 @@ def test_fast_log_loss_large(num_samples, num_classes):
     across various data dimensions.
     """
     y_true, y_pred = generate_y_true_and_y_pred_proba(num_samples=num_samples, num_classes=num_classes)
-    assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred, num_classes=num_classes)
+    assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred, num_classes=num_classes, rtol=1e-6)
 
 
 @pytest.mark.parametrize('num_configs,num_samples,num_classes',
@@ -100,10 +111,11 @@ def test_fast_log_loss_bulk(num_configs, num_samples, num_classes):
         num_samples=num_samples,
         num_classes=num_classes
     )
+    rtol = 1e-6
 
     for i in range(num_configs):
         y_pred = y_pred_bulk[i]
-        assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred, num_classes=num_classes)
+        assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred, num_classes=num_classes, rtol=rtol)
 
     config_weights = np.random.rand(num_configs)
     config_weights /= np.sum(config_weights)
@@ -111,7 +123,7 @@ def test_fast_log_loss_bulk(num_configs, num_samples, num_classes):
 
     y_pred_bulk_weighted = [pred * weight for pred, weight in zip(y_pred_bulk, config_weights)]
     y_pred_ensemble = np.sum(y_pred_bulk_weighted, axis=0)
-    assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred_ensemble, num_classes=num_classes)
+    assert_fast_log_loss_equivalence(y_true=y_true, y_pred=y_pred_ensemble, num_classes=num_classes, rtol=rtol)
 
     y_pred_bulk_opt = _fast_log_loss.extract_true_class_prob_bulk(y_true, y_pred_bulk)
     y_pred_bulk_opt_weighted = [pred * weight for pred, weight in zip(y_pred_bulk_opt, config_weights)]
@@ -120,4 +132,4 @@ def test_fast_log_loss_bulk(num_configs, num_samples, num_classes):
     fast_loss_ensemble = _fast_log_loss.fast_log_loss(y_true, y_pred_opt_ensemble)
     ag_loss_ensemble = log_loss(y_true, y_pred_ensemble)
 
-    np.testing.assert_allclose(ag_loss_ensemble, fast_loss_ensemble)
+    np.testing.assert_allclose(ag_loss_ensemble, fast_loss_ensemble, rtol=rtol)


### PR DESCRIPTION
Related to #20 

Add `fast_roc_auc`, which uses a C++ compiled implementation of `roc_auc` for a >2x speedup.

This is an improvement over our prior `roc_auc` implementation (`ag_roc_auc`).

To use `fast_roc_auc`, you will need to compile the C++ code via the newly added `compile.sh`. If you attempt to run the code without doing so, it will error with a message containing the terminal command needed to compile the code.

Here is an example output from `run_bench_roc_auc.py`

```
Benchmarking roc_auc... (num_samples=2, num_repeats=1000
	Time = 0.3948 ms	| Rel Speedup = 1.0x	| Score = 0.0	| sk_roc_auc
	Time = 0.0538 ms	| Rel Speedup = 7.3x	| Score = 0.0	| ag_roc_auc
	Time = 0.0084 ms	| Rel Speedup = 46.8x	| Score = 0.0	| fast_roc_auc_cpp
Benchmarking roc_auc... (num_samples=10, num_repeats=1000
	Time = 0.4101 ms	| Rel Speedup = 1.0x	| Score = 0.1875	| sk_roc_auc
	Time = 0.0539 ms	| Rel Speedup = 7.6x	| Score = 0.1875	| ag_roc_auc
	Time = 0.0084 ms	| Rel Speedup = 48.7x	| Score = 0.1875	| fast_roc_auc_cpp
Benchmarking roc_auc... (num_samples=100, num_repeats=1000
	Time = 0.4213 ms	| Rel Speedup = 1.0x	| Score = 0.4277597402597403	| sk_roc_auc
	Time = 0.0559 ms	| Rel Speedup = 7.5x	| Score = 0.42775974025974023	| ag_roc_auc
	Time = 0.0092 ms	| Rel Speedup = 45.7x	| Score = 0.4277597402597403	| fast_roc_auc_cpp
Benchmarking roc_auc... (num_samples=1000, num_repeats=1000
	Time = 0.5901 ms	| Rel Speedup = 1.0x	| Score = 0.4813428059395802	| sk_roc_auc
	Time = 0.0900 ms	| Rel Speedup = 6.6x	| Score = 0.4813428059395801	| ag_roc_auc
	Time = 0.0204 ms	| Rel Speedup = 28.9x	| Score = 0.4813428059395801	| fast_roc_auc_cpp
Benchmarking roc_auc... (num_samples=2000, num_repeats=1000
	Time = 0.7811 ms	| Rel Speedup = 1.0x	| Score = 0.5006057186644378	| sk_roc_auc
	Time = 0.1594 ms	| Rel Speedup = 4.9x	| Score = 0.5006057186644378	| ag_roc_auc
	Time = 0.0585 ms	| Rel Speedup = 13.4x	| Score = 0.5006057186644378	| fast_roc_auc_cpp
Benchmarking roc_auc... (num_samples=5000, num_repeats=100
	Time = 1.3484 ms	| Rel Speedup = 1.0x	| Score = 0.4909501567205458	| sk_roc_auc
	Time = 0.4038 ms	| Rel Speedup = 3.3x	| Score = 0.49095015672054576	| ag_roc_auc
	Time = 0.2453 ms	| Rel Speedup = 5.5x	| Score = 0.49095015672054576	| fast_roc_auc_cpp
Benchmarking roc_auc... (num_samples=10000, num_repeats=100
	Time = 2.3446 ms	| Rel Speedup = 1.0x	| Score = 0.509796231110791	| sk_roc_auc
	Time = 0.8498 ms	| Rel Speedup = 2.8x	| Score = 0.5097962311107911	| ag_roc_auc
	Time = 0.5501 ms	| Rel Speedup = 4.3x	| Score = 0.509796231110791	| fast_roc_auc_cpp
Benchmarking roc_auc... (num_samples=100000, num_repeats=20
	Time = 23.7546 ms	| Rel Speedup = 1.0x	| Score = 0.4982425920099391	| sk_roc_auc
	Time = 12.0591 ms	| Rel Speedup = 2.0x	| Score = 0.4982425920099391	| ag_roc_auc
	Time = 6.8111 ms	| Rel Speedup = 3.5x	| Score = 0.4982425920099391	| fast_roc_auc_cpp
Benchmarking roc_auc... (num_samples=1000000, num_repeats=3
	Time = 280.7703 ms	| Rel Speedup = 1.0x	| Score = 0.4997539871865995	| sk_roc_auc
	Time = 154.8101 ms	| Rel Speedup = 1.8x	| Score = 0.4997539871865995	| ag_roc_auc
	Time = 82.6302 ms	| Rel Speedup = 3.4x	| Score = 0.4997539871865996	| fast_roc_auc_cpp
```

In terms of simulation speed, when combined with the `log_loss` optimization from #23, we are ~3x faster:


Prior to metric optimizations:
```
Fitting Fold 1/5 (R1S1)...
    train_datasets: 104/104 | train_tasks: 1040
    test_datasets : 26/26 | test_tasks : 260
    n_configs=608/608
2023-05-03 02:47:59,089	INFO worker.py:1538 -- Started a local Ray instance.
1	: Train: 3.17 | 17.89s	| Tr Change: 2.840	| Conf Options: 608	| ray | CatBoost_r9_BAG_L1
2	: Train: 2.7 | 135.53s	| Tr Change: 0.471	| Conf Options: 607	| ray | NeuralNetFastAI_r35_BAG_L1
3	: Train: 2.4 | 193.36s	| Tr Change: 0.292	| Conf Options: 606	| ray | LightGBM_r12_BAG_L1
4	: Train: 2.28 | 250.21s	| Tr Change: 0.127	| Conf Options: 605	| ray | ExtraTrees_r23_BAG_L1
5	: Train: 2.17 | 306.84s	| Tr Change: 0.108	| Conf Options: 604	| ray | LightGBM_r146_BAG_L1
6	: Train: 2.1 | 363.53s	| Tr Change: 0.073	| Conf Options: 603	| ray | CatBoost_r12_BAG_L1
7	: Train: 2.05 | 421.3s	| Tr Change: 0.047	| Conf Options: 602	| ray | CatBoost_r72_BAG_L1
8	: Train: 2.03 | 477.13s	| Tr Change: 0.024	| Conf Options: 601	| ray | LightGBM_r66_BAG_L1
9	: Train: 2.01 | 535.3s	| Tr Change: 0.018	| Conf Options: 600	| ray | ExtraTrees_r11_BAG_L1
10	: Train: 1.99 | 591.18s	| Tr Change: 0.016	| Conf Options: 599	| ray | RandomForest_r37_BAG_L1
selected ['CatBoost_r9_BAG_L1', 'NeuralNetFastAI_r35_BAG_L1', 'LightGBM_r12_BAG_L1', 'ExtraTrees_r23_BAG_L1', 'LightGBM_r146_BAG_L1', 'CatBoost_r12_BAG_L1', 'CatBoost_r72_BAG_L1', 'LightGBM_r66_BAG_L1', 'ExtraTrees_r11_BAG_L1', 'RandomForest_r37_BAG_L1']
test_score: 2.4736221676682826
```

This PR (Slight train/test score difference due to small rounding errors changing how ties occur slightly, can be ignored):
```
Fitting Fold 1/5 (R1S1)...
    train_datasets: 104/104 | train_tasks: 1040
    test_datasets : 26/26 | test_tasks : 260
    n_configs=608/608
2023-05-03 07:52:31,321	INFO worker.py:1538 -- Started a local Ray instance.
1	: Train: 3.17 | 12.87s	| Tr Change: 2.841	| Conf Options: 608	| ray | CatBoost_r9_BAG_L1
2	: Train: 2.69 | 58.34s	| Tr Change: 0.471	| Conf Options: 607	| ray | NeuralNetFastAI_r35_BAG_L1
3	: Train: 2.4 | 79.4s	| Tr Change: 0.290	| Conf Options: 606	| ray | LightGBM_r12_BAG_L1
4	: Train: 2.28 | 100.5s	| Tr Change: 0.128	| Conf Options: 605	| ray | ExtraTrees_r23_BAG_L1
5	: Train: 2.17 | 120.45s	| Tr Change: 0.110	| Conf Options: 604	| ray | LightGBM_r146_BAG_L1
6	: Train: 2.09 | 141.09s	| Tr Change: 0.073	| Conf Options: 603	| ray | CatBoost_r12_BAG_L1
7	: Train: 2.05 | 161.86s	| Tr Change: 0.047	| Conf Options: 602	| ray | CatBoost_r72_BAG_L1
8	: Train: 2.02 | 181.43s	| Tr Change: 0.024	| Conf Options: 601	| ray | LightGBM_r82_BAG_L1
9	: Train: 2.0 | 201.27s	| Tr Change: 0.019	| Conf Options: 600	| ray | RandomForest_r16_BAG_L1
10	: Train: 1.99 | 221.73s	| Tr Change: 0.019	| Conf Options: 599	| ray | NeuralNetFastAI_r41_BAG_L1
selected ['CatBoost_r9_BAG_L1', 'NeuralNetFastAI_r35_BAG_L1', 'LightGBM_r12_BAG_L1', 'ExtraTrees_r23_BAG_L1', 'LightGBM_r146_BAG_L1', 'CatBoost_r12_BAG_L1', 'CatBoost_r72_BAG_L1', 'LightGBM_r82_BAG_L1', 'RandomForest_r16_BAG_L1', 'NeuralNetFastAI_r41_BAG_L1']
test_score: 2.3743008798881537
```