### PR TITLE
add proxy_fit_metric_map, speed up simulations by 4x

### DIFF
--- a/autogluon_zeroshot/metrics/_fast_log_loss.py
+++ b/autogluon_zeroshot/metrics/_fast_log_loss.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numpy as np
 
 from autogluon.core.metrics import make_scorer
@@ -8,13 +10,21 @@ def extract_true_class_prob(y_true: np.ndarray, y_pred: np.ndarray) -> np.ndarra
     Note: Data must be pre-normalized. The data is not normalized within this function for speed purposes.
     The predictions can then be passed to _fast_log_loss.
     :param y_true: an array with shape (n_samples,) that contains all the classes, values must be in [0, n_classes]
-    :param y_pred: an array with shape (n_samples, n_classes) whose values are the prediction probability assigned to
-    the ground truth classes.
+    :param y_pred:
+        an array with shape (n_samples, n_classes) whose values are the prediction probability assigned to
+        the ground truth classes.
+        Can also be in shape (n_samples,), where it is then interpreted as binary classification pred probabilities.
     :return: an array with shape (n_samples) that contains the predicted probability of the true class for each sample
     """
-    assert y_pred.ndim == 2
     assert len(y_true) == len(y_pred)
-    return y_pred[range(len(y_pred)), y_true]
+
+    if y_pred.ndim == 1:
+        y_true_bool = y_true.astype(np.bool8)
+        true_class_prob = y_true_bool*y_pred + ~y_true_bool*(1-y_pred)
+    else:
+        assert y_pred.ndim == 2
+        true_class_prob = y_pred[range(len(y_pred)), y_true]
+    return true_class_prob
 
 
 def extract_true_class_prob_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) -> np.ndarray:
@@ -26,17 +36,34 @@ def extract_true_class_prob_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) ->
     `extract_true_class_prob` in a for loop.
 
     :param y_true: an array with shape (n_samples,) that contains all the classes, values must be in [0, n_class[
-    :param y_pred_bulk: an array with shape (n_configs, n_samples, n_classes) whose values are the prediction probability
-    assigned to the ground truth classes for each config/model.
+    :param y_pred_bulk:
+        an array with shape (n_configs, n_samples, n_classes) whose values are the prediction probability
+        assigned to the ground truth classes for each config/model.
+        Can also be an array with shape (n_configs, n_samples), where it is then interpreted as binary classification.
     :return: an array with shape (n_configs, n_samples) that contains for each config the predicted probability
     of the true class for each sample.
     """
     ndim = y_pred_bulk.ndim
-    if ndim != 3:
-        raise AssertionError(f'Only y_pred_bulk.ndim==3 is valid for this function (ndim={ndim})')
+    if ndim not in [2, 3]:
+        raise AssertionError(f'y_pred_bulk.ndim must be either 2 or 3 for this function (ndim={ndim})')
     assert y_pred_bulk.shape[1] == len(y_true), f"y_true and y_pred_bulk have different numbers of samples! " \
                                                 f"({len(y_true)}, {y_pred_bulk.shape[1]})"
-    return y_pred_bulk[:, range(y_pred_bulk.shape[1]), y_true]
+    if ndim == 2:
+        y_true_bool = y_true.astype(np.bool8)
+        true_class_prob_bulk = y_true_bool * y_pred_bulk + ~y_true_bool * (1 - y_pred_bulk)
+    else:  # ndim == 3
+        true_class_prob_bulk = y_pred_bulk[:, range(y_pred_bulk.shape[1]), y_true]
+    true_class_prob_bulk = _epsilon(true_class_prob_bulk).astype(np.float32)
+    return true_class_prob_bulk
+
+
+def _preprocess_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    y_pred_bulk = extract_true_class_prob_bulk(y_true=y_true, y_pred_bulk=y_pred_bulk)
+    return y_true, y_pred_bulk
+
+
+def _epsilon(y_pred, eps=1e-15):
+    return np.clip(y_pred.astype(float), eps, 1 - eps)
 
 
 def _mean_log_loss(true_class_prob: np.ndarray) -> float:
@@ -45,6 +72,7 @@ def _mean_log_loss(true_class_prob: np.ndarray) -> float:
 
 def _fast_log_loss_end_to_end(y_true: np.ndarray, y_pred: np.ndarray) -> float:
     true_class_prob = extract_true_class_prob(y_true=y_true, y_pred=y_pred)
+    true_class_prob = _epsilon(true_class_prob).astype(np.float32)
     return _mean_log_loss(true_class_prob=true_class_prob)
 
 
@@ -75,6 +103,9 @@ fast_log_loss = make_scorer('log_loss',
                             optimum=0,
                             greater_is_better=False,
                             needs_proba=True)
+
+
+fast_log_loss.preprocess_bulk = _preprocess_bulk
 
 
 # Score function for probabilistic classification

--- a/autogluon_zeroshot/metrics/_fast_roc_auc.py
+++ b/autogluon_zeroshot/metrics/_fast_roc_auc.py
@@ -1,3 +1,7 @@
+from typing import Tuple
+
+import numpy as np
+
 from autogluon.core.metrics import make_scorer
 
 from ._roc_auc_cpp import CppAuc
@@ -10,3 +14,10 @@ fast_roc_auc_cpp = make_scorer('roc_auc',
                                CppAuc().roc_auc_score,
                                greater_is_better=True,
                                needs_threshold=True)
+
+
+def _preprocess_bulk(y_true: np.ndarray, y_pred_bulk: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    return y_true.astype(np.bool8), y_pred_bulk.astype(np.float32)
+
+
+fast_roc_auc_cpp.preprocess_bulk = _preprocess_bulk

--- a/autogluon_zeroshot/metrics/bench_utils.py
+++ b/autogluon_zeroshot/metrics/bench_utils.py
@@ -24,8 +24,11 @@ def generate_y_true_and_y_pred_proba(num_samples, num_classes, random_seed=0):
 def generate_y_true_and_y_pred_proba_bulk(num_configs, num_samples, num_classes, random_seed=0):
     np.random.seed(seed=random_seed)
     y_true = np.random.randint(0, num_classes, num_samples)
-    y_pred_bulk = [normalize(np.random.rand(num_samples, num_classes), axis=1, norm='l1') for _ in range(num_configs)]
-    y_pred_bulk = np.array(y_pred_bulk)
+    if num_classes == 2:
+        y_pred_bulk = np.array([np.random.rand(num_samples) for _ in range(num_configs)])
+    else:
+        y_pred_bulk = [normalize(np.random.rand(num_samples, num_classes), axis=1, norm='l1') for _ in range(num_configs)]
+        y_pred_bulk = np.array(y_pred_bulk)
     return y_true, y_pred_bulk
 
 

--- a/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
+++ b/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
@@ -1,17 +1,16 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import numpy as np
 import ray
 
-from autogluon.core.metrics import get_metric
+from autogluon.core.metrics import get_metric, Scorer
 from autogluon.core.models.greedy_ensemble.ensemble_selection import EnsembleSelection
 from .configuration_list_scorer import ConfigurationListScorer
 
 from .simulation_context import ZeroshotSimulatorContext
 from .simulation_context import TabularModelPredictions
 from ..utils.rank_utils import RankScorer
-from ..metrics import _fast_log_loss
-from ..metrics import _fast_roc_auc
+from ..metrics import _fast_log_loss, _fast_roc_auc
 
 
 @ray.remote
@@ -34,10 +33,17 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
                  max_fold: Optional[float] = None,
                  backend: str = 'native',
                  use_fast_metrics: bool = True,
+                 proxy_fit_metric_map: Optional[Union[dict, str]] = 'default',
                  ):
         """
         TODO: Add docstring
         :param use_fast_metrics: If True, will leverage optimized eval metrics to speed up config scoring.
+        :param proxy_fit_metric_map:
+            If eval_metric is among the keys in the `proxy_fit_metric_map` dictionary,
+            the value eval_metric will be used during the weighted ensemble fitting process as a proxy.
+            For example, the proxy metric could be faster to compute while producing a similar end result.
+            If None: Do not use proxy metrics, equivalent to {}.
+            If 'default': set to {'roc_auc': 'log_loss'}, making 'log_loss' a proxy to 'roc_auc'
         """
         super(EnsembleSelectionConfigScorer, self).__init__(datasets=datasets)
         if zeroshot_gt is None:
@@ -57,6 +63,12 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         assert backend in ['native', 'ray']
         self.backend = backend
         self.use_fast_metrics = use_fast_metrics
+        if proxy_fit_metric_map is None:
+            proxy_fit_metric_map = {}
+        elif isinstance(proxy_fit_metric_map, str):
+            assert proxy_fit_metric_map == 'default'
+            proxy_fit_metric_map = {'roc_auc': 'log_loss'}  # log_loss is fast to compute and a good proxy for roc_auc
+        self.proxy_fit_metric_map = proxy_fit_metric_map
 
     @classmethod
     def from_zsc(cls, zeroshot_simulator_context: ZeroshotSimulatorContext, **kwargs):
@@ -67,37 +79,28 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             **kwargs,
         )
 
-    def _get_fast_metric_if_exist(self,
-                                  metric_name: str,
-                                  problem_type: str,
-                                  y_val: np.array,
-                                  pred_val: np.array,
-                                  y_test: np.array,
-                                  pred_test: np.array,
-                                  ):
+    def _get_metric_from_name(self, metric_name: str, problem_type: str) -> Scorer:
+        if self.use_fast_metrics:
+            return self._get_fast_metric_if_exist(metric_name=metric_name, problem_type=problem_type)
+        else:
+            return get_metric(metric=metric_name, problem_type=problem_type)
+
+    def _get_fast_metric_if_exist(self, metric_name: str, problem_type: str) -> Scorer:
         """
         # TODO: Add docstring
         # TODO: Consider making this more standardized.
         #  Currently fast_log_loss needs a bit of special preprocessing of the data and isn't a straightforward replace.
-        # TODO: Add fast_roc_auc
-        # TODO: Add fast_rmse
         """
-        if metric_name == 'log_loss' and problem_type == 'multiclass':
+        if metric_name == 'log_loss':
             # TODO: Can be even faster if we transform pred_val and pred_test
             #  as a preprocessing step to TabularModelPredictions.
             #  This would avoid ever having to pay the preprocessing time cost, and would massively reduce memory usage.
             eval_metric = _fast_log_loss.fast_log_loss
-            pred_val = _fast_log_loss.extract_true_class_prob_bulk(y_true=y_val, y_pred_bulk=pred_val)
-            pred_test = _fast_log_loss.extract_true_class_prob_bulk(y_true=y_test, y_pred_bulk=pred_test)
         elif metric_name == 'roc_auc':
-            y_val = y_val.astype(np.bool8)
-            y_test = y_test.astype(np.bool8)
-            pred_val = pred_val.astype(np.float32)
-            pred_test = pred_test.astype(np.float32)
             eval_metric = _fast_roc_auc.fast_roc_auc_cpp
         else:
-            eval_metric = get_metric(metric_name)
-        return eval_metric, y_val, pred_val, y_test, pred_test
+            eval_metric = get_metric(metric=metric_name, problem_type=problem_type)
+        return eval_metric
 
     def run_dataset(self, dataset, models):
         fold = self.dataset_name_to_fold_dict[dataset]
@@ -113,26 +116,26 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
 
         pred_val, pred_test = self.zeroshot_pred_proba.predict(dataset=dataset, fold=fold, splits=['val', 'test'], models=models)
 
-        if self.use_fast_metrics:
-            eval_metric, y_val, pred_val, y_test, pred_test = self._get_fast_metric_if_exist(
-                metric_name=metric_name,
-                problem_type=problem_type,
-                y_val=y_val,
-                pred_val=pred_val,
-                y_test=y_test,
-                pred_test=pred_test,
-            )
-        else:
-            eval_metric = get_metric(metric_name)
+        fit_metric_name = self.proxy_fit_metric_map.get(metric_name, metric_name)
+
+        eval_metric = self._get_metric_from_name(metric_name=metric_name, problem_type=problem_type)
+        fit_eval_metric = self._get_metric_from_name(metric_name=fit_metric_name, problem_type=problem_type)
+
+        if hasattr(fit_eval_metric, 'preprocess_bulk'):
+            y_val, pred_val = fit_eval_metric.preprocess_bulk(y_val, pred_val)
 
         weighted_ensemble = EnsembleSelection(
             ensemble_size=self.ensemble_size,
             problem_type=problem_type,
-            metric=eval_metric,
+            metric=fit_eval_metric,
             **self.ensemble_selection_kwargs,
         )
 
         weighted_ensemble.fit(predictions=pred_val, labels=y_val)
+
+        if hasattr(eval_metric, 'preprocess_bulk'):
+            y_test, pred_test = eval_metric.preprocess_bulk(y_test, pred_test)
+
         if eval_metric.needs_pred:
             y_test_pred = weighted_ensemble.predict(pred_test)
         else:

--- a/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
+++ b/autogluon_zeroshot/simulation/ensemble_selection_config_scorer.py
@@ -33,7 +33,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
                  max_fold: Optional[float] = None,
                  backend: str = 'native',
                  use_fast_metrics: bool = True,
-                 proxy_fit_metric_map: Optional[Union[dict, str]] = 'default',
+                 proxy_fit_metric_map: Optional[Union[dict, str]] = None,  # TODO: Add unit test
                  ):
         """
         TODO: Add docstring
@@ -43,7 +43,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
             the value eval_metric will be used during the weighted ensemble fitting process as a proxy.
             For example, the proxy metric could be faster to compute while producing a similar end result.
             If None: Do not use proxy metrics, equivalent to {}.
-            If 'default': set to {'roc_auc': 'log_loss'}, making 'log_loss' a proxy to 'roc_auc'
+            If 'roc_auc_to_log_loss': set to {'roc_auc': 'log_loss'}, making 'log_loss' a proxy to 'roc_auc'
         """
         super(EnsembleSelectionConfigScorer, self).__init__(datasets=datasets)
         if zeroshot_gt is None:
@@ -66,7 +66,7 @@ class EnsembleSelectionConfigScorer(ConfigurationListScorer):
         if proxy_fit_metric_map is None:
             proxy_fit_metric_map = {}
         elif isinstance(proxy_fit_metric_map, str):
-            assert proxy_fit_metric_map == 'default'
+            assert proxy_fit_metric_map == 'roc_auc_to_log_loss'
             proxy_fit_metric_map = {'roc_auc': 'log_loss'}  # log_loss is fast to compute and a good proxy for roc_auc
         self.proxy_fit_metric_map = proxy_fit_metric_map
 

--- a/scripts/benchmark_metrics/run_bench_log_loss.py
+++ b/scripts/benchmark_metrics/run_bench_log_loss.py
@@ -5,10 +5,10 @@ from sklearn.metrics import log_loss as sk_log_loss
 from autogluon_zeroshot.metrics._fast_log_loss import \
     fast_log_loss_end_to_end, fast_log_loss, extract_true_class_prob
 from autogluon_zeroshot.metrics.bench_utils import benchmark_metrics_speed, print_benchmark_result,\
-    get_eval_speed, generate_y_true_and_y_pred_proba
+    get_eval_speed, generate_y_true_and_y_pred_proba, generate_y_true_and_y_pred_binary
 
 
-def benchmark_log_loss(num_samples: int, num_classes: int, num_repeats: int, rtol=1e-06):
+def benchmark_log_loss(num_samples: int, num_classes: int, num_repeats: int, rtol=1e-06, binary_format=False):
     """
     Benchmarks 4 log_loss computing methods, verifying equivalent scores and comparing compute speed
 
@@ -24,8 +24,15 @@ def benchmark_log_loss(num_samples: int, num_classes: int, num_repeats: int, rto
         Technically for the purposes of ZS simulation, we can run the preprocessing logic on all y_pred for all models,
         thus never paying the cost of preprocessing and massively reducing memory usage.
     """
-    print(f'Benchmarking log_loss... (num_samples={num_samples}, num_classes={num_classes}, num_repeats={num_repeats}')
-    y_true, y_pred = generate_y_true_and_y_pred_proba(num_samples=num_samples, num_classes=num_classes)
+    print(f'Benchmarking log_loss... (num_samples={num_samples}, '
+          f'num_classes={num_classes}, '
+          f'binary_format={binary_format}, '
+          f'num_repeats={num_repeats}')
+    if binary_format:
+        assert num_classes == 2
+        y_true, y_pred = generate_y_true_and_y_pred_binary(num_samples=num_samples)
+    else:
+        y_true, y_pred = generate_y_true_and_y_pred_proba(num_samples=num_samples, num_classes=num_classes)
 
     benchmark_metrics = [
         (sk_log_loss, 'sk_log_loss'),
@@ -151,4 +158,12 @@ if __name__ == '__main__':
         (1000000, 10, 3),
         (1000000, 100, 3),
     ]:
-        benchmark_log_loss(num_samples=num_samples, num_classes=num_classes, num_repeats=num_repeats)
+        if num_classes == 2:
+            benchmark_log_loss(num_samples=num_samples,
+                               num_classes=num_classes,
+                               num_repeats=num_repeats,
+                               binary_format=True)
+        benchmark_log_loss(num_samples=num_samples,
+                           num_classes=num_classes,
+                           num_repeats=num_repeats,
+                           binary_format=False)


### PR DESCRIPTION
add proxy_fit_metric_map, speed up simulations by ~4x, cleanup fast_metric logic, add binary support to fast_log_loss

Added a trick to use `log_loss` metric during the fit of EnsembleSelection when eval_metric is `roc_auc`. `log_loss` is a good proxy metric for `roc_auc` while being much faster to compute, saving a lot of time in simulations.


Mainline:

```
Fitting Fold 1/5 (R1S1)...
    train_datasets: 104/104 | train_tasks: 1040
    test_datasets : 26/26 | test_tasks : 260
    n_configs=608/608
2023-05-03 07:52:31,321	INFO worker.py:1538 -- Started a local Ray instance.
1	: Train: 3.17 | 12.87s	| Tr Change: 2.841	| Conf Options: 608	| ray | CatBoost_r9_BAG_L1
2	: Train: 2.69 | 58.34s	| Tr Change: 0.471	| Conf Options: 607	| ray | NeuralNetFastAI_r35_BAG_L1
3	: Train: 2.4 | 79.4s	| Tr Change: 0.290	| Conf Options: 606	| ray | LightGBM_r12_BAG_L1
4	: Train: 2.28 | 100.5s	| Tr Change: 0.128	| Conf Options: 605	| ray | ExtraTrees_r23_BAG_L1
5	: Train: 2.17 | 120.45s	| Tr Change: 0.110	| Conf Options: 604	| ray | LightGBM_r146_BAG_L1
6	: Train: 2.09 | 141.09s	| Tr Change: 0.073	| Conf Options: 603	| ray | CatBoost_r12_BAG_L1
7	: Train: 2.05 | 161.86s	| Tr Change: 0.047	| Conf Options: 602	| ray | CatBoost_r72_BAG_L1
8	: Train: 2.02 | 181.43s	| Tr Change: 0.024	| Conf Options: 601	| ray | LightGBM_r82_BAG_L1
9	: Train: 2.0 | 201.27s	| Tr Change: 0.019	| Conf Options: 600	| ray | RandomForest_r16_BAG_L1
10	: Train: 1.99 | 221.73s	| Tr Change: 0.019	| Conf Options: 599	| ray | NeuralNetFastAI_r41_BAG_L1
selected ['CatBoost_r9_BAG_L1', 'NeuralNetFastAI_r35_BAG_L1', 'LightGBM_r12_BAG_L1', 'ExtraTrees_r23_BAG_L1', 'LightGBM_r146_BAG_L1', 'CatBoost_r12_BAG_L1', 'CatBoost_r72_BAG_L1', 'LightGBM_r82_BAG_L1', 'RandomForest_r16_BAG_L1', 'NeuralNetFastAI_r41_BAG_L1']
test_score: 2.3743008798881537
```

This PR (test score diff can generally be ignored, mostly random noise):

```
Fitting Fold 1/5 (R1S1)...
	train_datasets: 104/104 | train_tasks: 1040
	test_datasets : 26/26 | test_tasks : 260
	n_configs=608/608
2023-05-04 21:46:39,710	INFO worker.py:1538 -- Started a local Ray instance.
1	: Train: 3.17 | 11.78s	| Tr Change: 2.841	| Conf Options: 608	| ray | CatBoost_r9_BAG_L1
2	: Train: 2.66 | 26.57s	| Tr Change: 0.507	| Conf Options: 607	| ray | NeuralNetFastAI_r35_BAG_L1
3	: Train: 2.4 | 31.38s	| Tr Change: 0.261	| Conf Options: 606	| ray | LightGBM_r111_BAG_L1
4	: Train: 2.28 | 37.16s	| Tr Change: 0.113	| Conf Options: 605	| ray | ExtraTrees_r23_BAG_L1
5	: Train: 2.19 | 40.82s	| Tr Change: 0.090	| Conf Options: 604	| ray | LightGBM_r159_BAG_L1
6	: Train: 2.13 | 45.64s	| Tr Change: 0.067	| Conf Options: 603	| ray | NeuralNetFastAI_r34_BAG_L1
7	: Train: 2.06 | 51.32s	| Tr Change: 0.063	| Conf Options: 602	| ray | CatBoost_r62_BAG_L1
8	: Train: 2.02 | 56.73s	| Tr Change: 0.045	| Conf Options: 601	| ray | CatBoost_r90_BAG_L1
9	: Train: 1.98 | 59.43s	| Tr Change: 0.038	| Conf Options: 600	| ray | RandomForest_r28_BAG_L1
10	: Train: 1.95 | 64.03s	| Tr Change: 0.028	| Conf Options: 599	| ray | NeuralNetFastAI_r7_BAG_L1
selected ['CatBoost_r9_BAG_L1', 'NeuralNetFastAI_r35_BAG_L1', 'LightGBM_r111_BAG_L1', 'ExtraTrees_r23_BAG_L1', 'LightGBM_r159_BAG_L1', 'NeuralNetFastAI_r34_BAG_L1', 'CatBoost_r62_BAG_L1', 'CatBoost_r90_BAG_L1', 'RandomForest_r28_BAG_L1', 'NeuralNetFastAI_r7_BAG_L1']
test_score: 2.4499736042136506
```