### PR TITLE
Fix AutoML scoring

### DIFF
--- a/autogluon_zeroshot/simulation/simulation_context.py
+++ b/autogluon_zeroshot/simulation/simulation_context.py
@@ -190,6 +190,10 @@ class ZeroshotSimulatorContext:
             dataset_folds += self.dataset_parent_to_fold_map[d]
         return dataset_folds
 
+    @property
+    def tid_to_dataset_dict(self):
+        return {v: k for k, v in self.dataset_to_tid_dict.items()}
+
     def get_configs(self) -> list:
         """Return all valid configs"""
         return list(self.df_results_by_dataset_vs_automl['framework'].unique())

--- a/autogluon_zeroshot/utils/rank_utils.py
+++ b/autogluon_zeroshot/utils/rank_utils.py
@@ -95,8 +95,10 @@ class RankScorer:
         self.pct = pct
         self.include_partial = include_partial
         df_pivot = df_results_by_dataset.pivot_table(values=metric_error_col, index=dataset_col, columns=framework_col)
-        df_pivot.values.sort(axis=1)
-        self.error_dict = {dataset: df_pivot.loc[dataset].dropna() for dataset in datasets}
+        df_pivot.values.sort(axis=1)  # NOTE: The framework columns are now no longer correct. Do not use them.
+
+        # tolist to drop the framework col name, since it is no longer ordered.
+        self.error_dict = {dataset: df_pivot.loc[dataset].dropna().tolist() for dataset in datasets}
 
     def rank(self, dataset: str, error: float) -> float:
         """


### PR DESCRIPTION
Fixed AutoML scoring in eval scripts.

I noticed that `AutoGluon best quality` seemed to perform unreasonably well in mainline.
Further, `AutoGluon medium quality` was being beaten by `AutoGluon medium quality only LightGBM`, which definitely shouldn't be the case.

I have confirmed that the rankings are now correct by comparing with a separate ranking & evaluation script I have used for past papers. After the fix, the results are identical.

## The bug

```python3
df_pivot.values.sort(axis=1)
self.error_dict = {dataset: df_pivot.loc[dataset].dropna() for dataset in datasets}
```

The above code makes it so the framework column names are no longer assigned to the correct metric_error.
Instead, the first column is always assigned to the oracle best metric_error among them, and the last column is always the oracle worst metric_error.
Their order was:
```
AutoGluon best quality (ensemble)
AutoGluon best quality
AutoGluon high quality (ensemble)
AutoGluon medium quality (ensemble)
AutoGluon medium quality only LightGBM
AutoGluon medium quality
```

So `AutoGluon best quality (ensemble)` was being assigned the best metric_error among all 6 results for every task, making it essentially unbeatable.

When accessed in this way, the bug occurs:

```python3
automl_errors = repo._zeroshot_context.rank_scorer_vs_automl.error_dict[dataset_fold_name]
for method, test_error in automl_errors.to_dict().items():
```

## The fix

Instead of accessing the AutoML metric_error through the ranker, which was not intended, instead fetch the scores from the source: `repo._zeroshot_context.df_results_by_dataset_automl`.

This guarantees the metric_error values are correct.

## The result

Now, zeroshot ensemble portfolios are correctly showing that they are beating best quality, which aligns with my expectations.

## Output Comparison

Output of `evaluate_baselines.py`:

Mainline (Bugged):

```
\begin{tabular}{lrr}
\toprule
{} &   rank &  normalized\_score \\
method                                 &        &                   \\
\midrule
AutoGluon best quality (ensemble)      &  57.52 &              0.29 \\
Zeroshot-20-40 (ensemble)              &  92.59 &              0.41 \\
Zeroshot-20-80 (ensemble)              &  92.72 &              0.41 \\
Zeroshot-20-20 (ensemble)              &  93.44 &              0.41 \\
AutoGluon best quality                 &  94.31 &              0.40 \\
Zeroshot-40-80 (ensemble)              &  94.49 &              0.40 \\
Zeroshot-40-20 (ensemble)              &  94.80 &              0.40 \\
Zeroshot-40-40 (ensemble)              &  95.04 &              0.40 \\
Zeroshot-80-20 (ensemble)              &  96.25 &              0.40 \\
Zeroshot-10-20 (ensemble)              &  99.72 &              0.44 \\
Zeroshot-5-20 (ensemble)               & 111.54 &              0.47 \\
Zeroshot-20-1 (ensemble)               & 126.53 &              0.48 \\
Zeroshot-40-1 (ensemble)               & 127.56 &              0.47 \\
Zeroshot-80-1 (ensemble)               & 130.07 &              0.47 \\
Zeroshot-10-1 (ensemble)               & 133.79 &              0.51 \\
AutoGluon high quality (ensemble)      & 138.70 &              0.51 \\
Zeroshot-5-1 (ensemble)                & 142.76 &              0.53 \\
AutoGluon medium quality (ensemble)    & 206.73 &              0.65 \\
AutoGluon medium quality only LightGBM & 279.84 &              0.77 \\
AutoGluon medium quality               & 392.69 &              0.91 \\
\bottomrule
\end{tabular}
```

This PR (Fixed):

```
\begin{tabular}{lrr}
\toprule
{} &   rank &  normalized\_score \\
method                                 &        &                   \\
\midrule
Zeroshot-20-40 (ensemble)              &  92.77 &              0.41 \\
Zeroshot-20-80 (ensemble)              &  92.89 &              0.41 \\
Zeroshot-20-20 (ensemble)              &  93.63 &              0.41 \\
Zeroshot-40-80 (ensemble)              &  94.78 &              0.40 \\
Zeroshot-40-20 (ensemble)              &  95.09 &              0.40 \\
Zeroshot-40-40 (ensemble)              &  95.36 &              0.40 \\
Zeroshot-80-20 (ensemble)              &  96.51 &              0.40 \\
Zeroshot-10-20 (ensemble)              &  99.91 &              0.44 \\
Zeroshot-5-20 (ensemble)               & 111.71 &              0.47 \\
AutoGluon best quality (ensemble)      & 115.02 &              0.42 \\
Zeroshot-20-1 (ensemble)               & 126.68 &              0.48 \\
Zeroshot-40-1 (ensemble)               & 127.76 &              0.47 \\
Zeroshot-80-1 (ensemble)               & 130.27 &              0.47 \\
Zeroshot-10-1 (ensemble)               & 133.97 &              0.51 \\
Zeroshot-5-1 (ensemble)                & 143.02 &              0.53 \\
AutoGluon best quality                 & 151.83 &              0.51 \\
AutoGluon high quality (ensemble)      & 153.58 &              0.50 \\
AutoGluon medium quality (ensemble)    & 178.62 &              0.58 \\
AutoGluon medium quality               & 240.19 &              0.68 \\
AutoGluon medium quality only LightGBM & 330.56 &              0.84 \\
\bottomrule
\end{tabular}
```